### PR TITLE
Prevent horizontal scroll on html and body elements

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -44,6 +44,7 @@ body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  overflow-x: hidden;
 }
 
 a {


### PR DESCRIPTION
The animations on the header of the Photos page would cause an unwanted horizontal scroll on the `html` element. 

Here's what that looked like, notice a black border was added to the `html` element (just to showcase the issue). The space to the right was caused by the animations. Also notice the horizontal scrollbar would appear on the bottom.

![Screenshot from 2021-01-03 10 14 34](https://user-images.githubusercontent.com/8296281/103483396-f09f9200-4dde-11eb-876a-8898e6e5e3c7.png)
