### PR TITLE
[WT-131]: fix/remove-Virus-Scanner-redirect

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,7 @@ const excludedPaths: string[] = [
   `/img`,
   `/logos`,
   `/js`,
+  `/Virus%20Scanner`,
   `DPA.pdf`,
 ];
 


### PR DESCRIPTION
Now /Virus Scanner already redrirect to 404.
In the excluded routes, it has been added:
* /Virus%20Scanner