### PR TITLE
[WEB-25]: fix/Update footer redirect in Firefox

### DIFF
--- a/components/virus-scanner/HeroSection.js
+++ b/components/virus-scanner/HeroSection.js
@@ -7,10 +7,9 @@ import React, { useState, Fragment } from 'react';
 import { Transition } from '@headlessui/react';
 import { UilRedo, UilExclamationOctagon } from '@iconscout/react-unicons';
 import { CheckCircle, WarningCircle } from 'phosphor-react';
-import ReactMarkdown from 'react-markdown';
 import Image from 'next/image';
 
-const HeroSection = ({ textContent, lang }) => {
+const HeroSection = ({ textContent }) => {
   const [isSelectedFile, setIsSelectedFile] = useState(false);
   const [isScannig, setIsScannig] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -182,7 +181,7 @@ const HeroSection = ({ textContent, lang }) => {
           {/* Title and subtitle */}
           <div className="mb-10 flex flex-col items-center space-y-5 text-center lg:mb-0 lg:items-start lg:justify-between lg:text-left">
             <div className="flex w-full flex-col lg:w-[297px] lg:space-y-5">
-              <h1 className="text-5xl font-semibold tracking-tighter">{textContent.title}</h1>
+              <h1 className="text-5xl font-semibold">{textContent.title}</h1>
               <h2 className="pt-5 text-xl font-normal text-cool-gray-80 lg:pt-0">
                 {textContent.subtitle1}
                 <div className="hidden h-5 lg:flex" />

--- a/pages/cyber-awareness.js
+++ b/pages/cyber-awareness.js
@@ -3,10 +3,10 @@ import cookies from '../lib/cookies';
 import Navbar from '../components/layout/Navbar';
 import Layout from '../components/layout/Layout';
 import HeroSection from '../components/cyber-awareness/HeroSection';
-import Footer from '../components/layout/Footer';
 import InfoSection from '../components/cyber-awareness/InfoSection';
 import SuiteSection from '../components/cyber-awareness/SuiteSection';
 import VideoSection from '../components/cyber-awareness/VideoSection';
+import Footer from '../components/layout/Footer';
 
 const CyberAwareness = ({ metatagsDescriptions, textContent, footerLang, navbarLang, lang }) => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'cyber-awareness');

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -37,6 +37,12 @@ html {
   overflow-x: hidden;
 }
 
+@-moz-document url-prefix() {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 html,
 body {
   padding: 0;


### PR DESCRIPTION
When navigating to another page via the footer in Firefox, sometimes the view stays in the footer because the scrollTop does not work properly. Scroll-behavior: auto has been added to fix the problem.