### PR TITLE
[_]: fix/price cards for monthly products

### DIFF
--- a/src/components/prices/PriceTable.tsx
+++ b/src/components/prices/PriceTable.tsx
@@ -238,7 +238,9 @@ export default function PriceTable({
                   priceBefore={
                     billingFrequency === Interval.Year && !coupon
                       ? products.individuals?.[Interval.Month][index].price * 12
-                      : product.price
+                      : coupon
+                      ? product.price
+                      : undefined
                   }
                   lang={lang}
                   currency={currency}


### PR DESCRIPTION
Remove the crossed price before for monthly products for pricing page.