### PR TITLE
[_]: fix/percent off for lifetime plans

### DIFF
--- a/src/pages/lifetime/index.tsx
+++ b/src/pages/lifetime/index.tsx
@@ -33,7 +33,7 @@ const Lifetime = ({ lang, metatagsDescriptions, langJson, testimonialsJson, foot
         textContent={langJson.PaymentSection}
         discount={discount}
         lang={lang}
-        percent={'70%'}
+        percent={'75%'}
         showPriceBefore
         lifetimeMode="custom-disc"
       />

--- a/src/pages/lifetime/index.tsx
+++ b/src/pages/lifetime/index.tsx
@@ -25,6 +25,7 @@ const Lifetime = ({ lang, metatagsDescriptions, langJson, testimonialsJson, foot
 
       <HeroSection
         textContent={langJson.HeroSection}
+        percent="75"
         previewImg="/images/lifetime/file_item.webp"
         bgImage="/images/lifetime/celebration/normal-bg.png"
       />


### PR DESCRIPTION
Fix the CTA text for lifetime page. Adding 75% instead of 70%.