### PR TITLE
[MKT-442]: fix/broken links

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -60,6 +60,7 @@ module.exports = {
         '/use-cases',
         '/internxt-library',
         '/online-privacy-ebook',
+        '/token',
       ].map((src) => ({
         source: src,
         destination: '/',
@@ -79,6 +80,7 @@ module.exports = {
         '/use-cases',
         '/internxt-library',
         '/online-privacy-ebook',
+        '/token',
       ].map((src) => ({
         source: `/:lang${src}`,
         destination: '/:lang',

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -36,6 +36,7 @@ interface LayoutProps {
   readonly specialOffer?: string;
   readonly isBannerFixed?: boolean;
   readonly lang?: string;
+  readonly pathnameForSEO?: string;
 }
 
 const imageLang = ['ES', 'FR', 'EN'];
@@ -47,6 +48,7 @@ export default function Layout({
   segmentName = null,
   disableMailerlite = false,
   specialOffer,
+  pathnameForSEO,
   disableDrift = true,
   isBannerFixed,
   isProduction = process.env.NODE_ENV === 'production',
@@ -55,7 +57,7 @@ LayoutProps) {
   const pageURL = segmentName === 'home' ? '' : segmentName;
   const router = useRouter();
   const { dialogIsOpen } = useGlobalDialog();
-  const pathname = router.pathname === '/' ? '' : router.pathname;
+  const pathname = pathnameForSEO ? pathnameForSEO : router.pathname === '/' ? '' : router.pathname;
   const lang = router.locale;
   const shouldShowBanner = !EXCLUDED_PATHS_FOR_BANNER.includes(pathname) && dialogIsOpen(GlobalDialog.TopBanner);
 

--- a/src/pages/file-converter/[filename].tsx
+++ b/src/pages/file-converter/[filename].tsx
@@ -20,9 +20,16 @@ const FileConverter = ({
   pathname,
 }) => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === pathname);
+  const pathnameForSEO = `/file-converter/${pathname}`;
 
   return (
-    <Layout segmentName="File Converter" title={metatags[0].title} description={metatags[0].description} lang={lang}>
+    <Layout
+      segmentName="File Converter"
+      title={metatags[0].title}
+      description={metatags[0].description}
+      lang={lang}
+      pathnameForSEO={pathnameForSEO}
+    >
       <Navbar textContent={navbarLang} lang={lang} cta={['default']} fixed />
 
       <ConverterSection


### PR DESCRIPTION
Adding a redirect to the main page when the user wants to visit the non existent /token LP.

Fixed the canonical and alternative links for file-converter tool.