### PR TITLE
Fix Title Non-Responsive in HeroSection Component

### DIFF
--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -61,7 +61,7 @@ export default function HeroSection({ textContent, lang, isHomePageV2 }: HeroSec
               textContent={titleAndOnePlanText}
               header={
                 <div className="flex w-max flex-col gap-9">
-                  <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-4 max-w-sm md:max-w-lg">
                     <Header maxWidth="max-w-[500px]" className="text-gray-100">
                       {textContent.title.line1} <span className="text-primary">{textContent.title.blueText}</span>
                       {textContent.title.line2}{' '}


### PR DESCRIPTION
### Ensure title is responsive in small viewports

#### Summary

This pull request fixes the issue where the title in the `HeroSection` component was not responsive on smaller screens. The lack of a `max-width` constraint caused layout problems, such as the title overflowing or not scaling correctly.

#### How to Test

1. Navigate to [ internxt.com](https://internxt.com/)
2. Resize the browser window to simulate smaller screen sizes.


#### Screenshots
Original
![image](https://github.com/user-attachments/assets/418d6d48-e9b4-4067-ba4a-5e9f73d717d4)
Fixed
![image](https://github.com/user-attachments/assets/20223380-4a7f-41dc-9974-540268aa0bd5)


