### PR TITLE
[MKT_461]: fix/ missing label in cloud-object-storage page

### DIFF
--- a/src/components/cloud-object-storage/HowMuchYouNeedSection.tsx
+++ b/src/components/cloud-object-storage/HowMuchYouNeedSection.tsx
@@ -159,6 +159,7 @@ export const HowMuchYouNeedSection = ({ textContent }: HowMuchYouNeedSectionProp
                 </div>
               </div>
               {/* Percent download slider */}
+              <p className="font-medium text-gray-100">{textContent.percentDownloadPerMonth}</p>
               <div className="flex flex-row items-end gap-4">
                 <RangeSlider min={1} max={100} rangeItems={[]} valueLabelFormat={percentDownloadValueLabelFormat} />
                 <div className="flex w-full max-w-[90px] items-center justify-center rounded-lg border border-gray-10 px-4 py-2.5">


### PR DESCRIPTION
Added missing label in cloud-object-storage page
