### PR TITLE
[MKT_487]: Update/Pcloud alternative Landing Page

### DIFF
--- a/src/assets/lang/en/pcloud-alternative.json
+++ b/src/assets/lang/en/pcloud-alternative.json
@@ -1,7 +1,7 @@
 {
   "HeaderSection": {
     "title": "Switch to Internxt",
-    "description": "Internxt provides the private cloud storage you can trust, with open-source transparency and built-in post-quantum encryption to keep your data safe and secure.",
+    "description": "The most private cloud storage, with open-source transparency and built-in post-quantum encryption to keep your data safe and secure.",
 
     "useCode": {
       "line1": "Use code ",

--- a/src/assets/lang/en/pcloud-alternative.json
+++ b/src/assets/lang/en/pcloud-alternative.json
@@ -1,18 +1,17 @@
 {
   "HeaderSection": {
-    "title": "Internxt: a more secure pCloud alternative",
-    "description": "With phishing emails targeting pCloud users, the company denies a breach but gives no clear answers about how hackers obtained user emails.",
-    "description2": "Internxt provides the private cloud storage you can trust, with open-source transparency and built-in post-quantum encryption to keep your data safe and secure.",
+    "title": "Switch to Internxt",
+    "description": "Internxt provides the private cloud storage you can trust, with open-source transparency and built-in post-quantum encryption to keep your data safe and secure.",
 
     "useCode": {
       "line1": "Use code ",
       "code": "PCLOUD80",
-      "line2": " at checkout for 80% off any annual or lifetime Internxt plan."
+      "line2": "and claim your 80% discount."
     },
-    "cta": "Choose plan"
+    "cta": "Select plan"
   },
   "HeroSection": {
-    "title": "Internxt vs. pCloud comparison",
+    "title": "Internxt vs pCloud comparison",
     "description": "Discover characteristics of Internxt that make it a more private pCloud alternative",
     "tooltip": "Although pCloud identifies as a Swiss company and claims compliance with Swiss privacy laws, it operates entirely in Bulgaria. Therefore, Bulgarian privacy laws apply. Users should consider this distinction regarding their data protection.",
     "tableSection": {

--- a/src/assets/lang/en/pcloud-alternative.json
+++ b/src/assets/lang/en/pcloud-alternative.json
@@ -19,32 +19,32 @@
       "comparisons": {
         "codeTransparency": "Code transparency",
         "encryption": "Encryption",
+        "postQuantumEncryption": "Post-Quantum Encryption",
         "pricing": "Pricing",
         "securityAudits": "Security Audits",
         "liveSupport": "Live Support",
         "dataTrackers": "Data Trackers",
-        "privacyLaws": "Privacy Laws",
-        "postQuantumEncryption": "Post-Quantum Encryption"
+        "privacyLaws": "Privacy Laws"
       },
       "internxtFeatures": {
         "codeTransparency": "Open-Source",
         "encryption": "Included in all plans",
+        "postQuantumEncryption": "Yes",
         "pricing": "Competitive, no hidden costs",
         "securityAudits": "Regular security audits by the community",
         "liveSupport": "Yes",
         "dataTrackers": "No",
-        "privacyLaws": "GDPR, Spanish Data Protection Laws",
-        "postQuantumEncryption": "Yes"
+        "privacyLaws": "GDPR, Spanish Data Protection Laws"
       },
       "features": {
         "codeTransparency": "Closed-Source",
         "encryption": "Paid extra (pCloud Crypto)",
+        "postQuantumEncryption": "No",
         "pricing": "Affordable, but extra for encryption",
         "securityAudits": "Not available",
         "liveSupport": "No",
         "dataTrackers": "Yes (Facebook pixel, TikTok, Linkedin, etc)",
-        "privacyLaws": "Claims Swiss privacy laws",
-        "postQuantumEncryption": "No"
+        "privacyLaws": "Claims Swiss privacy laws"
       },
       "drag": {
         "line1": "Drag horizontally",

--- a/src/assets/lang/en/pcloud-alternative.json
+++ b/src/assets/lang/en/pcloud-alternative.json
@@ -1,11 +1,13 @@
 {
   "HeaderSection": {
     "title": "Internxt: a more secure pCloud alternative",
-    "description": "Worried about pCloud’s hidden source code and extra cost for encryption? Are you certain pCloud doesn’t store your password or access your files? Internxt offers free, built-in encryption and open-source transparency.",
+    "description": "With phishing emails targeting pCloud users, the company denies a breach but gives no clear answers about how hackers obtained user emails.",
+    "description2": "Internxt provides the private cloud storage you can trust, with open-source transparency and built-in post-quantum encryption to keep your data safe and secure.",
+
     "useCode": {
       "line1": "Use code ",
-      "code": "SPECIAL75",
-      "line2": " at checkout for 75% off any Internxt plan!"
+      "code": "PCLOUD80",
+      "line2": " at checkout for 80% off any annual or lifetime Internxt plan."
     },
     "cta": "Choose plan"
   },
@@ -21,16 +23,18 @@
         "securityAudits": "Security Audits",
         "liveSupport": "Live Support",
         "dataTrackers": "Data Trackers",
-        "privacyLaws": "Privacy Laws"
+        "privacyLaws": "Privacy Laws",
+        "postQuantumEncryption": "Post-Quantum Encryption"
       },
       "internxtFeatures": {
         "codeTransparency": "Open-Source",
         "encryption": "Included in all plans",
         "pricing": "Competitive, no hidden costs",
-        "securityAudits": "Regular security audits",
+        "securityAudits": "Regular security audits by the community",
         "liveSupport": "Yes",
         "dataTrackers": "No",
-        "privacyLaws": "GDPR, Spanish Data Protection Laws"
+        "privacyLaws": "GDPR, Spanish Data Protection Laws",
+        "postQuantumEncryption": "Yes"
       },
       "features": {
         "codeTransparency": "Closed-Source",
@@ -39,7 +43,8 @@
         "securityAudits": "Not available",
         "liveSupport": "No",
         "dataTrackers": "Yes (Facebook pixel, TikTok, Linkedin, etc)",
-        "privacyLaws": "Claims Swiss privacy laws"
+        "privacyLaws": "Claims Swiss privacy laws",
+        "postQuantumEncryption": "No"
       },
       "drag": {
         "line1": "Drag horizontally",
@@ -60,8 +65,8 @@
             "description": "As Internxt's code is open to anyone, everyone may examine it and ensure its security. This transparency guarantees that no vulnerabilities are hidden."
           },
           {
-            "title": "End-to-End Encryption",
-            "description": "Your data is encrypted on the client side, guaranteeing that only you can access it."
+            "title": "Post-Quantum encryption",
+            "description": "Internxt uses post-quantum end-to-end encryption. This encrypts files on your device and protects against the threat of quantum computers breaking current encryption technology."
           },
           {
             "title": "Audited",
@@ -182,8 +187,8 @@
   "UseCodeSection": {
     "title": {
       "line1": "Use code ",
-      "code": "SPECIAL75 ",
-      "line2": "for 75% off secure, encrypted cloud storage"
+      "code": "PCLOUD80 ",
+      "line2": " for 80% off secure, encrypted cloud storage"
     },
     "cta": "Choose plan"
   },
@@ -235,13 +240,48 @@
         "description": "Internxt operates with complete transparency, ensuring your data privacy is protected by European laws. Our GDPR compliance guarantees your information is handled securely and according to strict regulations."
       },
       {
-        "title": "Privacy-focused encryption",
-        "description": "Internxt includes zero knowledge and end-to-end encryption for your free and paid accounts. We only store the encrypted version of your data, and only you have the key to decrypt and access it."
+        "title": "Advanced encryption",
+        "description": "Internxt includes post-quantum encryption, the most secure and advanced cryptography available for free and paid accounts. We only store the encrypted version of your data, and only you have the key to decrypt and access it. "
       },
       {
         "title": "Flexible storage plans",
         "description": "Internxt Drive offers more paid plans and greater storage options than the pCloud pricing structure. If you need a pCloud alternative that offers monthly, annual, and lifetime plans, choose from any of our affordable plans, starting at 200GB to 10TB."
       }
     ]
+  },
+  "tableSection": {
+    "planTitles": {
+      "individuals": "Individual Plans",
+      "homePage": "Choose the right plan for you",
+      "lifetime": "Lifetime Plans",
+      "business": "Business Plans",
+      "lifetimeCampaign": {
+        "blueText": "Get 50% OFF",
+        "normalText": "all our exclusive lifetime plans"
+      }
+    },
+    "lifetimeDescription": "Buy once and get privacy and security forever.",
+    "planDescription": "All Internxt plans are fully featured with complete access to all of our privacy services. Security for all shapes and sizes.",
+    "businessDescription": "We’re currently working on new Internxt plans designed exclusively to defend your business, protect your employees, and secure your bottom line.",
+    "businessDescription2": "Ensure business data security with Internxt's encrypted cloud storage plans.",
+    "billingFrequency": {
+      "monthly": "Monthly",
+      "annually": "Annually",
+      "individual": "Individual",
+      "lifetime": "Lifetime",
+      "business": "Business"
+    },
+    "freePlanCard": {
+      "getStarted": "Get started with our free plan",
+      "enjoy10gb": "Enjoy 1GB forever and get access to all our services",
+      "upTo": "1GB",
+      "freeForever": "Free forever",
+      "cta": "Select plan"
+    },
+    "features": {
+      "endToEnd": "End-to-end encrypted",
+      "openSource": "Open-source and audited",
+      "anonymousAccount": "Anonymous account creation"
+    }
   }
 }

--- a/src/components/comparison/ComparisonHeader.tsx
+++ b/src/components/comparison/ComparisonHeader.tsx
@@ -25,7 +25,7 @@ export const ComparisonHeader = ({ textContent, redirectUrl, maxWithForTitle }: 
       </Header>
 
       <h2 className="max-w-3xl text-center text-xl">{textContent.description}</h2>
-      <h2 className="max-w-3xl text-center text-xl">{textContent.description2}</h2>
+
       {textContent.useCode ? <CodeComponent textContent={textContent.useCode} /> : undefined}
     </div>
 

--- a/src/components/comparison/ComparisonHeader.tsx
+++ b/src/components/comparison/ComparisonHeader.tsx
@@ -25,13 +25,13 @@ export const ComparisonHeader = ({ textContent, redirectUrl, maxWithForTitle }: 
       </Header>
 
       <h2 className="max-w-3xl text-center text-xl">{textContent.description}</h2>
+      <h2 className="max-w-3xl text-center text-xl">{textContent.description2}</h2>
       {textContent.useCode ? <CodeComponent textContent={textContent.useCode} /> : undefined}
     </div>
 
     <div className="relative z-10 flex flex-col items-center justify-center">
       <Link
         href={redirectUrl}
-        target="_blank"
         rel="noopener noreferrer"
         id="get-started-link"
         className="flex w-full items-center justify-center rounded-lg border border-transparent bg-white px-6 py-2 text-lg font-medium text-primary hover:bg-blue-10 focus:outline-none sm:inline-flex sm:w-auto"

--- a/src/components/comparison/pCloud-alternative/CouponSection.tsx
+++ b/src/components/comparison/pCloud-alternative/CouponSection.tsx
@@ -18,13 +18,12 @@ const CodeComponent = ({ textContent }) => (
 
 export const CouponSection = ({ textContent, redirectUrl }: UseCouponSectionProps) => {
   return (
-    <section className="flex flex-col bg-primary-dark py-20 px-5">
+    <section className="flex flex-col bg-primary-dark px-5 py-20">
       <div className="flex flex-col items-center gap-12 text-center">
         <div className="flex max-w-[810px] flex-col items-center gap-8 text-center">
           <CodeComponent textContent={textContent.title} />
           <Link
             href={redirectUrl}
-            target="_blank"
             rel="noopener noreferrer"
             id="get-started-link"
             className="flex w-full items-center justify-center rounded-lg border border-transparent bg-white px-6 py-2 text-lg font-medium text-primary hover:bg-blue-10 focus:outline-none sm:inline-flex sm:w-max"

--- a/src/components/comparison/pCloud-alternative/HeroSection.tsx
+++ b/src/components/comparison/pCloud-alternative/HeroSection.tsx
@@ -187,7 +187,6 @@ export const HeroSection = ({ textContent, logo, hideTooltip }: HeroSectionProps
             ))}
           </table>
         </div>
-        <SignUpBanner lang="en" textContent={bannerText.SignUpPCloudAlternativeBanner} />
       </div>
     </section>
   );

--- a/src/components/comparison/pCloud-alternative/HeroSection.tsx
+++ b/src/components/comparison/pCloud-alternative/HeroSection.tsx
@@ -3,6 +3,7 @@ import { Fragment } from 'react';
 import bannerText from '@/assets/lang/en/banners.json';
 import { Info } from '@phosphor-icons/react';
 import { Tooltip } from 'react-tooltip';
+import { post } from 'cypress/types/jquery';
 
 interface HeroSectionProps {
   textContent: any;
@@ -23,6 +24,7 @@ export const HeroSection = ({ textContent, logo, hideTooltip }: HeroSectionProps
         liveSupport: textContent.tableSection.internxtFeatures.liveSupport,
         dataTrackers: textContent.tableSection.internxtFeatures.dataTrackers,
         privacyLaws: textContent.tableSection.internxtFeatures.privacyLaws,
+        postQuantumEncryption: textContent.tableSection.internxtFeatures.postQuantumEncryption,
       },
     },
     {
@@ -36,6 +38,7 @@ export const HeroSection = ({ textContent, logo, hideTooltip }: HeroSectionProps
         liveSupport: textContent.tableSection.features.liveSupport,
         dataTrackers: textContent.tableSection.features.dataTrackers,
         privacyLaws: textContent.tableSection.features.privacyLaws,
+        postQuantumEncryption: textContent.tableSection.features.postQuantumEncryption,
       },
     },
   ];
@@ -80,6 +83,11 @@ export const HeroSection = ({ textContent, logo, hideTooltip }: HeroSectionProps
           id: 6,
           title: `${textContent.tableSection.comparisons.privacyLaws}`,
           feature: getFeature('privacyLaws'),
+        },
+        {
+          id: 7,
+          title: `${textContent.tableSection.comparisons.postQuantumEncryption}`,
+          feature: getFeature('postQuantumEncryption'),
         },
       ],
     },

--- a/src/components/comparison/pCloud-alternative/HeroSection.tsx
+++ b/src/components/comparison/pCloud-alternative/HeroSection.tsx
@@ -61,40 +61,40 @@ export const HeroSection = ({ textContent, logo, hideTooltip }: HeroSectionProps
         },
         {
           id: 2,
+          title: `${textContent.tableSection.comparisons.postQuantumEncryption}`,
+          feature: getFeature('postQuantumEncryption'),
+        },
+        {
+          id: 2,
           title: `${textContent.tableSection.comparisons.pricing}`,
           feature: getFeature('pricing'),
         },
         {
-          id: 3,
+          id: 4,
           title: `${textContent.tableSection.comparisons.securityAudits}`,
           feature: getFeature('securityAudits'),
         },
         {
-          id: 4,
+          id: 5,
           title: `${textContent.tableSection.comparisons.liveSupport}`,
           feature: getFeature('liveSupport'),
         },
         {
-          id: 5,
+          id: 6,
           title: `${textContent.tableSection.comparisons.dataTrackers}`,
           feature: getFeature('dataTrackers'),
         },
         {
-          id: 6,
+          id: 7,
           title: `${textContent.tableSection.comparisons.privacyLaws}`,
           feature: getFeature('privacyLaws'),
-        },
-        {
-          id: 7,
-          title: `${textContent.tableSection.comparisons.postQuantumEncryption}`,
-          feature: getFeature('postQuantumEncryption'),
         },
       ],
     },
   ];
 
   return (
-    <section className="overflow-hidden bg-gray-1 px-5 py-20">
+    <section className="overflow-hidden bg-white px-5 py-20">
       <div className="flex flex-col items-center justify-center gap-16">
         <div className="flex flex-col items-center gap-6 text-center">
           <h2 className="text-5xl font-semibold text-gray-100">{textContent.title}</h2>

--- a/src/components/comparison/pCloud-alternative/HeroSection.tsx
+++ b/src/components/comparison/pCloud-alternative/HeroSection.tsx
@@ -64,7 +64,7 @@ export const HeroSection = ({ textContent, logo, hideTooltip }: HeroSectionProps
           feature: getFeature('postQuantumEncryption'),
         },
         {
-          id: 2,
+          id: 3,
           title: `${textContent.tableSection.comparisons.pricing}`,
           feature: getFeature('pricing'),
         },

--- a/src/components/comparison/pCloud-alternative/HeroSection.tsx
+++ b/src/components/comparison/pCloud-alternative/HeroSection.tsx
@@ -3,7 +3,6 @@ import { Fragment } from 'react';
 import bannerText from '@/assets/lang/en/banners.json';
 import { Info } from '@phosphor-icons/react';
 import { Tooltip } from 'react-tooltip';
-import { post } from 'cypress/types/jquery';
 
 interface HeroSectionProps {
   textContent: any;

--- a/src/components/comparison/pCloud-alternative/WhyChooseInxtSection.tsx
+++ b/src/components/comparison/pCloud-alternative/WhyChooseInxtSection.tsx
@@ -52,7 +52,7 @@ export const WhyChooseInxtSection = ({ textContent }) => {
               key={card.title}
               className={`flex flex-col items-start justify-start rounded-2xl bg-gray-1 p-8 sm:p-10 md:max-w-[488px]`}
             >
-              <card.icon className="mb-6 text-4xl text-green" size={32} />
+              <card.icon className="mb-6 text-4xl text-green-1" size={32} />
               <div className="flex w-full max-w-[400px] flex-col">
                 <p className="mb-6 text-2xl font-medium text-gray-100">{card.title}</p>
                 <p className="text-base text-cool-gray-80 sm:text-lg">{card.subtitle}</p>

--- a/src/components/comparison/pCloud-alternative/WhyChooseInxtSection.tsx
+++ b/src/components/comparison/pCloud-alternative/WhyChooseInxtSection.tsx
@@ -70,7 +70,7 @@ export const WhyChooseInxtSection = ({ textContent }) => {
             quality={100}
             className="cursor-pointer"
             onClick={() => {
-              window.open(SIGNUP_DRIVE_WEB, '_blank', 'noopener noreferrer');
+              window.location.hash = 'priceTable';
             }}
           />
         </div>

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -114,6 +114,7 @@ export enum PromoCodeName {
   SoftSales = '70OFF4YOU',
   Christmas = 'SECRETSANTA80',
   Special80Coupon = 'SPECIAL80',
+  PcCloud = 'PCCLOUD80',
 }
 
 export interface PromoCodeProps {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -114,7 +114,7 @@ export enum PromoCodeName {
   SoftSales = '70OFF4YOU',
   Christmas = 'SECRETSANTA80',
   Special80Coupon = 'SPECIAL80',
-  PcCloud = 'PCCLOUD80',
+  PCLOUD80 = 'PCLOUD80',
 }
 
 export interface PromoCodeProps {

--- a/src/pages/pcloud-alternative.tsx
+++ b/src/pages/pcloud-alternative.tsx
@@ -42,7 +42,6 @@ const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
 
   const decimalDiscount = individualCoupon?.percentOff && 100 - individualCoupon.percentOff;
 
-  console.log('individualCoupon:', individualCoupon);
   return (
     <Layout title={metatags[0].title} description={metatags[0].description} segmentName="pCloud Comparison" lang={lang}>
       <Navbar textContent={navbarLang} lang={lang} cta={['priceTable']} fixed />

--- a/src/pages/pcloud-alternative.tsx
+++ b/src/pages/pcloud-alternative.tsx
@@ -24,7 +24,7 @@ const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
     coupon: individualCoupon,
     lifetimeCoupons,
   } = usePricing({
-    couponCode: PromoCodeName.PcCloud,
+    couponCode: PromoCodeName.PCLOUD80,
   });
 
   const onCheckoutButtonClicked = (priceId: string, isCheckoutForLifetime: boolean) => {
@@ -44,7 +44,7 @@ const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
   console.log('individualCoupon:', individualCoupon);
   return (
     <Layout title={metatags[0].title} description={metatags[0].description} segmentName="pCloud Comparison" lang={lang}>
-      <Navbar textContent={navbarLang} lang={lang} cta={['default']} fixed />
+      <Navbar textContent={navbarLang} lang={lang} cta={['priceTable']} fixed />
 
       <ComparisonHeader
         maxWithForTitle={'max-w-[600px]'}
@@ -53,8 +53,6 @@ const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
       />
 
       <HeroSection textContent={langJson.HeroSection} />
-
-      <TablesSection textContent={langJson.TablesSection} />
 
       <PricingSectionWrapper
         textContent={langJson.tableSection}
@@ -75,7 +73,10 @@ const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
             {langJson.tableSection.planDescription}
           </span>
         }
+        backgroundColorComponent="bg-gray-1"
       />
+
+      <TablesSection textContent={langJson.TablesSection} />
 
       <CouponSection textContent={langJson.UseCodeSection} redirectUrl="#priceTable" />
 

--- a/src/pages/pcloud-alternative.tsx
+++ b/src/pages/pcloud-alternative.tsx
@@ -14,6 +14,7 @@ import { PricingSectionWrapper } from '@/components/shared/pricing/PricingSectio
 import { PromoCodeName } from '@/lib/types';
 import usePricing from '@/hooks/usePricing';
 import { stripeService } from '@/components/services/stripe.service';
+import { SIGNUP_DRIVE_WEB } from '@/constants';
 
 const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, footerLang }): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'pcloud-alternative');
@@ -82,7 +83,7 @@ const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
 
       <IsPCloudSafeSection textContent={langJson.isPCloudSafeSection} />
 
-      <CtaSection textContent={langJson.CtaSection} url={'#priceTable'} />
+      <CtaSection textContent={langJson.CtaSection} url={SIGNUP_DRIVE_WEB} />
 
       <WhyChooseInxtSection textContent={langJson.WhyChooseInxtSection} />
 

--- a/src/pages/pcloud-alternative.tsx
+++ b/src/pages/pcloud-alternative.tsx
@@ -11,10 +11,38 @@ import CtaSection from '@/components/shared/CtaSection';
 import { SIGNUP_DRIVE_WEB } from '@/constants';
 import cookies from '@/lib/cookies';
 import { GetServerSidePropsContext } from 'next';
+import { PricingSectionWrapper } from '@/components/shared/pricing/PricingSectionWrapper';
+import { PromoCodeName } from '@/lib/types';
+import usePricing from '@/hooks/usePricing';
+import { stripeService } from '@/components/services/stripe.service';
 
 const pCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, footerLang }): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'pcloud-alternative');
+  const {
+    products,
+    loadingCards,
+    currencyValue,
+    coupon: individualCoupon,
+    lifetimeCoupons,
+  } = usePricing({
+    couponCode: PromoCodeName.PcCloud,
+  });
 
+  const onCheckoutButtonClicked = (priceId: string, isCheckoutForLifetime: boolean) => {
+    const couponCodeForCheckout = individualCoupon?.name;
+
+    stripeService.redirectToCheckout(
+      priceId,
+      currencyValue,
+      'individual',
+      isCheckoutForLifetime,
+      couponCodeForCheckout,
+    );
+  };
+
+  const decimalDiscount = individualCoupon?.percentOff && 100 - individualCoupon.percentOff;
+
+  console.log('individualCoupon:', individualCoupon);
   return (
     <Layout title={metatags[0].title} description={metatags[0].description} segmentName="pCloud Comparison" lang={lang}>
       <Navbar textContent={navbarLang} lang={lang} cta={['default']} fixed />
@@ -22,18 +50,39 @@ const pCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
       <ComparisonHeader
         maxWithForTitle={'max-w-[600px]'}
         textContent={langJson.HeaderSection}
-        redirectUrl={'/pricing'}
+        redirectUrl={'#priceTable'}
       />
 
       <HeroSection textContent={langJson.HeroSection} />
 
       <TablesSection textContent={langJson.TablesSection} />
 
-      <CouponSection textContent={langJson.UseCodeSection} redirectUrl="/pricing" />
+      <PricingSectionWrapper
+        textContent={langJson.tableSection}
+        decimalDiscount={{
+          individuals: decimalDiscount,
+          lifetime: decimalDiscount,
+        }}
+        lifetimeCoupons={lifetimeCoupons}
+        lang={lang}
+        products={products}
+        loadingCards={loadingCards}
+        onCheckoutButtonClicked={onCheckoutButtonClicked}
+        hideSwitchSelector
+        hideBusinessSelector
+        hideFreeCard
+        CustomDescription={
+          <span className="text-regular max-w-[800px] text-xl text-gray-80">
+            {langJson.tableSection.planDescription}
+          </span>
+        }
+      />
+
+      <CouponSection textContent={langJson.UseCodeSection} redirectUrl="#priceTable" />
 
       <IsPCloudSafeSection textContent={langJson.isPCloudSafeSection} />
 
-      <CtaSection textContent={langJson.CtaSection} url={SIGNUP_DRIVE_WEB} />
+      <CtaSection textContent={langJson.CtaSection} url={'#priceTable'} />
 
       <WhyChooseInxtSection textContent={langJson.WhyChooseInxtSection} />
 

--- a/src/pages/pcloud-alternative.tsx
+++ b/src/pages/pcloud-alternative.tsx
@@ -15,7 +15,7 @@ import { PromoCodeName } from '@/lib/types';
 import usePricing from '@/hooks/usePricing';
 import { stripeService } from '@/components/services/stripe.service';
 
-const pCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, footerLang }): JSX.Element => {
+const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, footerLang }): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'pcloud-alternative');
   const {
     products,
@@ -111,4 +111,4 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   };
 }
 
-export default pCloudComparison;
+export default PCloudComparison;

--- a/src/pages/pcloud-alternative.tsx
+++ b/src/pages/pcloud-alternative.tsx
@@ -8,7 +8,6 @@ import Layout from '@/components/layout/Layout';
 import { MinimalFooter } from '@/components/layout/footers/MinimalFooter';
 import Navbar from '@/components/layout/navbars/Navbar';
 import CtaSection from '@/components/shared/CtaSection';
-import { SIGNUP_DRIVE_WEB } from '@/constants';
 import cookies from '@/lib/cookies';
 import { GetServerSidePropsContext } from 'next';
 import { PricingSectionWrapper } from '@/components/shared/pricing/PricingSectionWrapper';


### PR DESCRIPTION
This PR updates the Pcloud alternative landing page.

Key Changes:
- Content Updates:
Changed the JSON file according to the new content

- Button Redirection:
Modified the redirection logic for all buttons to ensure they navigate to the appropriate sections.

- Table Enhancements:
Added new elements to the feature comparison table to include post-quantum encryption.

- Visual Updates:
Adjusted colors across section.

- New Coupon Integration:
Introduced a new coupon code (PCLOUD80) for special discounts.

- Pricing Section Addition:
Added the pricing section to the page, only anual and lifetime.