### PR TITLE
[_]: Update/ PCComponentes Iframe Browser Language Detection

### DIFF
--- a/src/pages/pccomponentes-products.tsx
+++ b/src/pages/pccomponentes-products.tsx
@@ -153,11 +153,12 @@ const PCComponentesProducts = ({ metatagsDescriptions, textContent, lang }): JSX
 };
 
 export async function getServerSideProps(ctx) {
-  let lang = ctx.locale;
+  const acceptLanguage = ctx.req.headers['accept-language'];
 
-  if (!ALLOWED_LANGUAGES.includes(lang)) {
-    lang = 'es';
-  }
+  const browserLang = acceptLanguage.split(',')[0].split('-')[0];
+
+  const lang = ALLOWED_LANGUAGES.includes(browserLang) ? browserLang : 'es';
+
   const metatagsDescriptions = require(`@/assets/lang/${lang}/metatags-descriptions.json`);
   const textContent = require(`@/assets/lang/${lang}/priceCard.json`);
 


### PR DESCRIPTION
This PR implements Language detection for PCComponentes iFrame
1. The preferred browser language is now detected and used by using the Accept-Language header.
2. The detected language is validated against a list of allowed languages (ALLOWED_LANGUAGES), defaulting to es if no match is found.