### PR TITLE
[_]: fix/PcComponentes checkout opener

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -289,7 +289,7 @@ export function checkoutForPcComponentes({
 
     const checkoutUrl = AUTH_FLOW_URL + `${pathname}?${params.toString()}`;
 
-    window.open(checkoutUrl, '_parent', 'noopener noreferrer');
+    window.open(checkoutUrl, '_self', 'noopener noreferrer');
   }
   if (IFRAME_AUTH_ENABLED) {
     window.top?.postMessage({ action: 'checkout', planId: planId }, window.location.origin);


### PR DESCRIPTION
This PR changes the way we redirect to the checkout when inside the PCComponentes iFrame, replacing _parent with _self.

This should solve the issue since _parent is designed to open the link outside the iframe, while _self will open it within the iframe.