### PR TITLE
[_]: feat/new Text for english priceCard

### DIFF
--- a/src/assets/lang/en/priceCard.json
+++ b/src/assets/lang/en/priceCard.json
@@ -128,7 +128,7 @@
     },
     "worldCloudSecurityDay": {
       "title": "Internxt themed goodies:",
-      "gift": "Chance to win an Internxt x Swiss Peak backpack"
+      "gift": "Chance to win an Internxt backpack"
     },
 
     "cheaperThan": {


### PR DESCRIPTION
This PR changes the english green zone price card text for avoid a double line