### PR TITLE
[_]: feat:/ implement Consent Mode v2 for Google Tags and cookie banner 

### DIFF
--- a/public/js/cookiebanner.script.js
+++ b/public/js/cookiebanner.script.js
@@ -195,6 +195,14 @@ var injectScripts = function () {
           }),
             t('cookieConsentPrefs', encodeURIComponent(JSON.stringify(c)), { expires: o(365), path: '/' }),
             injectScripts();
+          if (typeof gtag === 'function') {
+            gtag('consent', 'update', {
+              ad_storage: 'granted',
+              analytics_storage: 'granted',
+              ad_user_data: 'granted',
+              ad_personalization: 'granted',
+            });
+          }
         }),
         e('body').on('click', '#cookieSettings', function () {
           e('input[name="gdprPrefItem"]:not(:disabled)').attr('data-compulsory', 'off').prop('checked', !0),

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -137,6 +137,20 @@ LayoutProps) {
           style={{ margin: 0, padding: 0, textDecoration: 'none', listStyle: 'none', boxSizing: 'border-box' }}
         ></style>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('consent', 'default', {
+                'ad_storage': 'denied',
+                'analytics_storage': 'denied',
+                'ad_user_data': 'denied',
+                'ad_personalization': 'denied'
+              });
+            `,
+          }}
+        />
 
         <script
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
Added default denied consent state before GTM load and enabled dynamic consent updates on user acceptance via cookie banner.