### PR TITLE
[_]: update/bitdefender banner sizes

### DIFF
--- a/src/components/converter-tool/ConversionTableSection.tsx
+++ b/src/components/converter-tool/ConversionTableSection.tsx
@@ -105,7 +105,7 @@ const ConversionTableSection = ({ textContent, lang }) => {
 
   return (
     <section className="bg-gray-1">
-      <div className="flex flex-col space-y-16 py-20 lg:items-center lg:justify-center">
+      <div className="flex flex-col space-y-16 py-16 lg:items-center lg:justify-center">
         <div className="flex w-full flex-col items-center justify-center px-6">
           <Image
             src={getImage(`/banners/Ban_Internext_728x90_${languageForImage}.jpg`)}

--- a/src/components/converter-tool/ExplanationSection.tsx
+++ b/src/components/converter-tool/ExplanationSection.tsx
@@ -14,7 +14,7 @@ const ExplanationSection = ({ textContent, bannerText, lang }) => {
 
   return (
     <section className="overflow-hidden bg-gray-1">
-      <div className="flex flex-col items-center justify-start space-y-16 px-5 pb-16 pt-20 lg:px-10">
+      <div className="flex flex-col items-center justify-start space-y-16 px-5 pb-16 pt-14 lg:px-10">
         <div className="flex w-full flex-col items-center justify-center">
           <Image
             src={getImage(`/banners/Ban_Internext_728x90_${languageForImage}.jpg`)}

--- a/src/components/converter-tool/HeroSection.tsx
+++ b/src/components/converter-tool/HeroSection.tsx
@@ -55,7 +55,7 @@ const HeroSection = ({ textContent }) => {
   }
 
   return (
-    <section className="pt-32 pb-20">
+    <section className="pb-20 pt-32">
       <div className="mx-3 flex md:mx-10 lg:mx-32">
         <div className="mx-auto flex w-full max-w-screen-xl flex-col items-center justify-center space-y-20">
           {/* Title and subtitle */}
@@ -168,7 +168,7 @@ const HeroSection = ({ textContent }) => {
               </div>
             </div>
             <button
-              className="absolute top-1/2 left-1/2 z-20 -translate-x-1/2 -translate-y-1/2 rotate-90 cursor-pointer items-center justify-center rounded-full border border-gray-20 bg-white p-2 lg:rotate-0"
+              className="absolute left-1/2 top-1/2 z-20 -translate-x-1/2 -translate-y-1/2 rotate-90 cursor-pointer items-center justify-center rounded-full border border-gray-20 bg-white p-2 lg:rotate-0"
               onClick={() => {
                 setReverse(!reverse);
                 if (reverse && value1) {

--- a/src/components/home/TestimonialsSection.tsx
+++ b/src/components/home/TestimonialsSection.tsx
@@ -65,20 +65,23 @@ const TestimonialsSection = ({
             {textContent.title.normal} <span className="text-primary">{textContent.title.blue}</span>
           </p>
         </div>
-        <div className="flex flex-col items-center justify-between gap-12 lg:flex-row" key={testimonials[0].review}>
-          <div className="flex max-w-[375px] flex-col gap-3 lg:h-[300px] ">
+        <div
+          className="flex max-w-[1200px] flex-col items-center justify-between gap-12 lg:flex-row"
+          key={testimonials[0].review}
+        >
+          <div className="flex max-w-[355px] flex-col gap-3 lg:h-[300px]">
             <AvatarAndText testimonial={testimonials[0]} textColor={textColor} />
             <p className={`text-start text-xl ${textColor ? textColor : 'text-gray-80'}`}>{testimonials[0].review}</p>
           </div>
-
-          <Image
-            src={getImage('/logos/featured/valencia_cf.webp')}
-            width={300}
-            height={300}
-            alt="Internxt x ValenciaCF"
-          />
-
-          <div className="flex max-w-[375px] flex-col  gap-3 lg:h-[300px] ">
+          <div className="flex max-w-[355px] flex-col items-center justify-center gap-3  lg:h-[300px] lg:pb-20">
+            <Image
+              src={getImage('/logos/featured/Picture1.png')}
+              width={350}
+              height={260}
+              alt="Internxt x ValenciaCF"
+            />
+          </div>
+          <div className="flex max-w-[355px] flex-col gap-3  lg:h-[300px]">
             <AvatarAndText testimonial={testimonials[1]} textColor={textColor} />
             <p className={`text-start text-xl ${textColor ? textColor : 'text-gray-80'}`}>{testimonials[1].review}</p>
           </div>

--- a/src/components/monitor/FeatureSection.tsx
+++ b/src/components/monitor/FeatureSection.tsx
@@ -124,7 +124,7 @@ const FeatureSection: React.FC<FeatureSectionProps> = ({ textContent, lang }) =>
           </div>
         ))}
       </div>
-      <div className="flex w-full flex-col items-center justify-center pb-20">
+      <div className="flex w-full flex-col items-center justify-center px-6 pb-20">
         <Image
           src={getImage(`/banners/Ban_Internext_728x90_${languageForImage}.jpg`)}
           alt="File Arrow Up icon"

--- a/src/components/monitor/FeatureSection.tsx
+++ b/src/components/monitor/FeatureSection.tsx
@@ -76,7 +76,7 @@ const FeatureSection: React.FC<FeatureSectionProps> = ({ textContent, lang }) =>
   return (
     <section>
       <div className="my-10 mb-20 flex flex-col items-center space-y-12 md:my-20 md:mb-32">
-        <div className="flex w-full flex-col items-center justify-center px-10 pb-10">
+        <div className="flex w-full flex-col items-center justify-center px-6 pb-10">
           <Image
             src={getImage(`/banners/Ban_Internext_728x90_${languageForImage}.jpg`)}
             alt="File Arrow Up icon"

--- a/src/components/monitor/components/EmailToolBar.tsx
+++ b/src/components/monitor/components/EmailToolBar.tsx
@@ -30,8 +30,8 @@ export const EmailToolbar = ({ textContent, isFetchingData, handleCheckEmail }: 
         />
       </div>
 
-      <div className="mt-5 flex flex-row items-center space-x-1 text-sm text-gray-50">
-        <Info size={16} data-tooltip-id="email-tooltip" />
+      <div className="mt-5 flex flex-row items-start justify-center px-10 text-sm text-gray-50">
+        <Info size={16} data-tooltip-id="email-tooltip" className="pt-1" />
         <span data-tooltip>{textContent.toolTip}</span>
         <Tooltip id="email-tooltip" place="top">
           {textContent.toolTipEmergent}

--- a/src/components/password-checker/HeroSection.tsx
+++ b/src/components/password-checker/HeroSection.tsx
@@ -144,8 +144,8 @@ const HeroSection = ({ textContent, lang }) => {
                 />
               ))}
             </div>
-            <div className="flex flex-row items-center space-x-1 text-sm text-gray-50">
-              <Info size={16} />
+            <div className="flex flex-row items-start space-x-1 px-10 text-sm text-gray-50">
+              <Info size={16} className="pt-1" />
               <span>{textContent.subtitle3}</span>
             </div>
           </div>

--- a/src/components/password-generator/HeroSection.tsx
+++ b/src/components/password-generator/HeroSection.tsx
@@ -44,7 +44,7 @@ const HeroSection = ({ textContent, lang }) => {
   const languageForImage = ['zh', 'zh-tw', 'ru', 'en'].includes(lang) ? 'en' : lang;
 
   return (
-    <section className=" relative flex flex-row items-start px-5 pb-8 pt-32">
+    <section className="flex items-start justify-center overflow-hidden px-10 pb-20 pt-32">
       <div className="hidden h-full w-full flex-col items-center justify-center lg:flex">
         <Image
           src={getImage(`/banners/Ban_Internext_160x600_en.jpg`)}
@@ -62,8 +62,8 @@ const HeroSection = ({ textContent, lang }) => {
           }
         />
       </div>
-      <div className="flex flex-col items-center justify-center pb-20">
-        <div className="flex w-full min-w-[700px] flex-col items-center justify-center space-y-16">
+      <div className="flex w-full flex-col items-center justify-center space-y-10  ">
+        <div className="flex flex-col items-center justify-center space-y-16">
           <div className="flex flex-col items-center space-y-5 text-center">
             <Header isToolsPage className="text-gray-100">
               {textContent.title}

--- a/src/components/password-generator/HeroSection.tsx
+++ b/src/components/password-generator/HeroSection.tsx
@@ -97,8 +97,8 @@ const HeroSection = ({ textContent, lang }) => {
                   />
                 ))}
               </div>
-              <div className="flex flex-row items-center justify-center space-x-1 text-gray-50">
-                <Info size={16} weight="bold" />
+              <div className="flex flex-row items-center justify-start space-x-3 text-gray-50">
+                <Info size={16} weight="bold" className="pt-2" />
                 <p className="text-sm">{textContent.info}</p>
               </div>
               <div className="flex w-full flex-col gap-2 md:flex-row">

--- a/src/components/password-generator/InfoSection.tsx
+++ b/src/components/password-generator/InfoSection.tsx
@@ -79,8 +79,8 @@ const InfoSection = ({
         <SignUpBanner textContent={bannerText} lang={lang as string} />
         {getSectionText(textContent.firstSection)}
         {getSectionText(textContent.secondSection)}
-        <div className="gap flex flex-row flex-wrap items-center justify-center ">
-          <div className="gap flex h-full flex-row flex-wrap gap-8 rounded-2xl p-10">
+        <div className="gap flex flex-row flex-wrap items-center justify-center bg-gray-1">
+          <div className="gap flex h-full flex-row flex-wrap gap-8 rounded-2xl px-10 pt-10">
             {cards1.map((item) => (
               <div className="1 100% flex flex-1" key={item.title}>
                 <div className="flex h-full flex-col rounded-2xl bg-white p-10">
@@ -96,7 +96,7 @@ const InfoSection = ({
             ))}
           </div>
         </div>
-        <div className="flex w-full flex-col items-center justify-center">
+        <div className="flex w-full flex-col items-center justify-center bg-gray-1">
           <Image
             src={getImage(`/banners/Ban_Internext_728x90_${languageForImage}.jpg`)}
             alt="File Arrow Up icon"

--- a/src/components/shared/sections/ToolsSection.tsx
+++ b/src/components/shared/sections/ToolsSection.tsx
@@ -11,7 +11,7 @@ import {
 } from '@phosphor-icons/react';
 import { useRouter } from 'next/router';
 
-export const ToolsSection = ({ textContent, lang }: { textContent: any; lang: string }) => {
+export const ToolsSection = ({ textContent, lang, bgColor }: { textContent: any; lang: string; bgColor?: string }) => {
   const router = useRouter();
   const pathname = router.pathname;
 
@@ -62,7 +62,7 @@ export const ToolsSection = ({ textContent, lang }: { textContent: any; lang: st
   const filteredCards = cards.filter((item) => item.pathname !== pathname);
 
   return (
-    <section className="flex justify-center overflow-hidden py-20">
+    <section className={`flex justify-center overflow-hidden py-20 ${bgColor}`}>
       <div className="flex max-w-[1000px] flex-col items-center justify-center space-y-16 px-5">
         <p className="max-w-[720px] text-center text-4xl font-semibold sm:text-5xl">
           {textContent.title.text1}

--- a/src/components/temp-email/HeroSection.tsx
+++ b/src/components/temp-email/HeroSection.tsx
@@ -229,8 +229,8 @@ export const HeroSection = ({ textContent, lang }) => {
   const languageForImage = ['zh', 'zh-tw', 'ru', 'en'].includes(lang) ? 'en' : lang;
 
   return (
-    <section className="flex items-start justify-center overflow-hidden px-6 pb-10 pt-32 lg:pb-20">
-      <div className="flex w-full flex-col items-center justify-center">
+    <section className="flex items-start justify-center overflow-hidden  px-6 pb-20 pt-32">
+      <div className="flex w-full flex-col items-center justify-center ">
         <Image
           src={getImage(`/banners/Ban_Internext_160x600_en.jpg`)}
           alt="BitDefender Vertical Banner"
@@ -247,8 +247,8 @@ export const HeroSection = ({ textContent, lang }) => {
           }
         />
       </div>
-      <div className="flex w-full flex-col items-center justify-center space-y-10 px-4 md:max-w-[1000px] ">
-        <div className="flex w-full max-w-[895px] flex-col items-center justify-center text-center lg:max-w-2xl">
+      <div className="flex w-full flex-col items-center justify-center space-y-10  px-2 md:max-w-[720px] ">
+        <div className="flex w-full max-w-[895px] flex-col items-center justify-center text-center lg:max-w-xl">
           <Header isToolsPage>{textContent.title}</Header>
           <p className="pt-5 text-xl text-gray-80">{textContent.subtitle}</p>
         </div>

--- a/src/components/temp-email/InfoSection.tsx
+++ b/src/components/temp-email/InfoSection.tsx
@@ -45,8 +45,8 @@ export const InfoSection = ({ textContent, bannerText, lang }) => {
   return (
     <section className="flex flex-col items-center justify-center overflow-hidden bg-gray-1 px-5 py-16">
       <div className="flex max-w-[1000px] flex-col items-center justify-center">
-        <div className="flex flex-col items-center justify-start space-y-16 px-5 pb-16 lg:px-10 lg:pt-20">
-          <div className="flex w-full flex-col items-center justify-center ">
+        <div className="flex flex-col items-center justify-start space-y-16 pb-16 lg:px-10">
+          <div className="flex w-full flex-col items-center justify-center">
             <Image
               src={getImage(`/banners/Ban_Internext_728x90_${languageForImage}.jpg`)}
               alt="File Arrow Up icon"

--- a/src/components/temp-email/InfoSection.tsx
+++ b/src/components/temp-email/InfoSection.tsx
@@ -45,7 +45,7 @@ export const InfoSection = ({ textContent, bannerText, lang }) => {
   return (
     <section className="flex flex-col items-center justify-center overflow-hidden bg-gray-1 px-5 py-16">
       <div className="flex max-w-[1000px] flex-col items-center justify-center">
-        <div className="flex flex-col items-center justify-start space-y-16 pb-16 lg:px-10">
+        <div className="flex flex-col items-center justify-start space-y-16  lg:px-10  lg:pt-6">
           <div className="flex w-full flex-col items-center justify-center">
             <Image
               src={getImage(`/banners/Ban_Internext_728x90_${languageForImage}.jpg`)}
@@ -167,7 +167,7 @@ export const InfoSection = ({ textContent, bannerText, lang }) => {
               </ul>
             </div>
 
-            <div className="flex w-full flex-col items-center justify-center">
+            <div className="flex w-full flex-col items-center justify-center pt-6">
               <Image
                 src={getImage(`/banners/Ban_Internext_728x90_${languageForImage}.jpg`)}
                 alt="File Arrow Up icon"

--- a/src/components/virus-scanner/FeaturesSection.tsx
+++ b/src/components/virus-scanner/FeaturesSection.tsx
@@ -94,7 +94,7 @@ const FeaturesSection = ({ textContent, bannerText, lang }) => {
                 }
               />
             </div>
-            <div id="incontent_3" className="flex w-full max-w-[1000px] justify-center"></div>
+
             {/* Free online scanner */}
             <div className="flex flex-col justify-center space-y-5 py-7 text-left md:max-w-3xl md:py-0 md:text-center">
               <p className=" text-4xl font-semibold">{textContent.freeOnlineScanner.title}</p>
@@ -127,7 +127,23 @@ const FeaturesSection = ({ textContent, bannerText, lang }) => {
                 />
               </div>
             </div>
-            <div id="incontent_4" className="flex w-full max-w-[1000px] justify-center"></div>
+            <div className="flex w-full flex-col items-center justify-center">
+              <Image
+                src={getImage(`/banners/Ban_Internext_728x90_${languageForImage}.jpg`)}
+                alt="File Arrow Up icon"
+                width={800}
+                height={110}
+                quality={100}
+                style={{ cursor: 'pointer' }}
+                onClick={() =>
+                  window.open(
+                    `https://www.bitdefender.com/pages/consumer/${languageForImage}/new/trial/ts-trial-3m/internxt/`,
+                    '_blank',
+                    'noopener noreferrer',
+                  )
+                }
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/password-generator.tsx
+++ b/src/pages/password-generator.tsx
@@ -48,7 +48,7 @@ const PasswordGenerator = ({
 
         <InfoSection textContent={langJson.InfoSection} bannerText={bannerText.SignUpPasswordGenerator} lang={lang} />
 
-        <ToolsSection textContent={toolsContent} lang={lang} />
+        <ToolsSection textContent={toolsContent} lang={lang} bgColor="bg-gray-1" />
 
         <CtaSection textContent={langJson.CtaSection} url={DRIVE_URL} />
 


### PR DESCRIPTION
This PR updates the layout of several components to improve responsiveness and visual consistency across different screen sizes. Specifically:

Resized banners to better fit the screen dimensions

Adjusted a couple of HeroSection components for improved layout and readability

Modified the TestimonialsSection to ensure it scales properly across viewports

These changes aim to enhance the user experience on both desktop and mobile devices.