### PR TITLE
[_]: feat/increase IR cookies lifetime

### DIFF
--- a/src/services/impact.service.ts
+++ b/src/services/impact.service.ts
@@ -58,10 +58,13 @@ export const handleImpact = async ({
   const randomUUID = impactAnonymousId ?? crypto.randomUUID();
 
   const expirationDate = new Date();
-  expirationDate.setHours(expirationDate.getHours() + 1);
+  expirationDate.setHours(expirationDate.getHours() + 2);
+
+  const anonymousDate = new Date();
+  anonymousDate.setFullYear(anonymousDate.getFullYear() + 10);
 
   document.cookie = `impactSource=${source};expires=${expirationDate.toUTCString()};domain=${COOKIE_DOMAIN};Path=/`;
-  document.cookie = `impactAnonymousId=${randomUUID};expires=${expirationDate.toUTCString()};domain=${COOKIE_DOMAIN};Path=/`;
+  document.cookie = `impactAnonymousId=${randomUUID};expires=${anonymousDate.toUTCString()};domain=${COOKIE_DOMAIN};Path=/`;
 
   try {
     await sendImpactTrack({ randomUUID, ip, userAgent, page });


### PR DESCRIPTION
This PR extends the expiration time of the Impact tracking cookies:

- `impactSource`: Now expires after 2 hours (previously 1 hour).
- `impactAnonymousId`: Now persists for 10 years to ensure users keep the same anonymous UUID across sessions and visits.

This change helps improve long-term user attribution and session tracking consistency.