### PR TITLE
[MKT_625]: feat/Implement hreflang tags and convert mobile buttons to crawlable links

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -107,6 +107,17 @@ export default function Layout({
         <link rel="icon" href="/favicon.ico" />
 
         <link rel="stylesheet" href="/cookiebanner.style.css" />
+
+        <link rel="alternate" hrefLang="en-US" href={`https://internxt.com${pathname}`} />
+        <link rel="alternate" hrefLang="es-ES" href={`https://internxt.com/es${pathname}`} />
+        <link rel="alternate" hrefLang="de-DE" href={`https://internxt.com/de${pathname}`} />
+        <link rel="alternate" hrefLang="fr-FR" href={`https://internxt.com/fr${pathname}`} />
+        <link rel="alternate" hrefLang="it-IT" href={`https://internxt.com/it${pathname}`} />
+        <link rel="alternate" hrefLang="ru-RU" href={`https://internxt.com/ru${pathname}`} />
+        <link rel="alternate" hrefLang="zh-CN" href={`https://internxt.com/zh${pathname}`} />
+        <link rel="alternate" hrefLang="zh-TW" href={`https://internxt.com/zh-tw${pathname}`} />
+        <link rel="alternate" hrefLang="x-default" href={`https://internxt.com${pathname}`} />
+
         <style
           style={{ margin: 0, padding: 0, textDecoration: 'none', listStyle: 'none', boxSizing: 'border-box' }}
         ></style>

--- a/src/components/layout/components/LanguageMobileBox.tsx
+++ b/src/components/layout/components/LanguageMobileBox.tsx
@@ -58,15 +58,17 @@ export default function LanguageMobileBox({ darkMode, singlesDay }: LanguageMobi
                 } max-h-48 space-y-2 overflow-y-auto p-4`}
               >
                 {filteredLanguages.map((language) => (
-                  <button
+                  <a
                     key={language.text}
-                    onClick={() => {
+                    href={`/${language.lang === 'en' ? '' : language.lang}${router.pathname}`}
+                    onClick={(e) => {
+                      e.preventDefault();
                       router.push(router.pathname, router.pathname, { locale: language.lang });
                     }}
-                    className="w-full py-2 text-center"
+                    className="block w-full py-2 text-center"
                   >
                     {language.text}
-                  </button>
+                  </a>
                 ))}
               </Disclosure.Panel>
             </Transition>

--- a/src/components/layout/components/LanguageMobileBox.tsx
+++ b/src/components/layout/components/LanguageMobileBox.tsx
@@ -60,7 +60,7 @@ export default function LanguageMobileBox({ darkMode, singlesDay }: LanguageMobi
                 {filteredLanguages.map((language) => (
                   <a
                     key={language.text}
-                    href={`/${language.lang === 'en' ? '' : language.lang}${router.pathname}`}
+                    href={`${language.lang === 'en' ? '' : `/${language.lang}`}${router.pathname}`}
                     onClick={(e) => {
                       e.preventDefault();
                       router.push(router.pathname, router.pathname, { locale: language.lang });


### PR DESCRIPTION
This PR is related to SEO improvements, enhancing positioning by providing more specific regional targeting and making navigation elements crawlable by search engines. This follows Google's best practices for international SEO and site architecture.

Key changes:
* Updated hreflang tags from simple language codes to language-region format (e.g., `hrefLang="en"` to `hrefLang="en-US"`)
* Converted navigation `<button>` elements to `<a>` tags with proper `href` attributes for crawlability