### PR TITLE
[MKT-667]:feat/Update AnalyticsService to support multiple GA tracking IDs

### DIFF
--- a/src/services/ga.services.ts
+++ b/src/services/ga.services.ts
@@ -76,7 +76,7 @@ const getPlanCategory = (planType: 'individual' | 'business'): string => {
 
 const normalizeSendTo = (sendTo?: string | string[]): string[] => {
   if (Array.isArray(sendTo)) {
-    return sendTo.filter(Boolean) as string[];
+    return sendTo.filter(Boolean);
   }
   return sendTo ? [sendTo] : [];
 };

--- a/src/services/ga.services.ts
+++ b/src/services/ga.services.ts
@@ -55,9 +55,7 @@ interface DataLayerEvent {
   checkout_step?: number;
 }
 
-const SEND_TO = [process.env.NEXT_PUBLIC_GA_ID, process.env.NEXT_PUBLIC_GA_CONTAINER].filter((id): id is string =>
-  Boolean(id),
-);
+const SEND_TO = [process.env.NEXT_PUBLIC_GA_ID, process.env.NEXT_PUBLIC_GA_CONTAINER].filter(Boolean) as string[];
 
 const DEFAULT_CURRENCY = 'eur';
 const DEFAULT_QUANTITY = 1;
@@ -76,18 +74,25 @@ const getPlanCategory = (planType: 'individual' | 'business'): string => {
   return planType === 'individual' ? 'Individual' : 'Business';
 };
 
+const normalizeSendTo = (sendTo?: string | string[]): string[] => {
+  if (Array.isArray(sendTo)) {
+    return sendTo.filter(Boolean) as string[];
+  }
+  return sendTo ? [sendTo] : [];
+};
+
 class AnalyticsService {
   private readonly sendTo: string[];
   private readonly defaultCurrency: string;
 
   constructor(sendTo?: string | string[], defaultCurrency: string = DEFAULT_CURRENCY) {
-    this.sendTo = Array.isArray(sendTo) ? (sendTo.filter(Boolean) as string[]) : sendTo ? [sendTo] : [];
+    this.sendTo = normalizeSendTo(sendTo);
     this.defaultCurrency = defaultCurrency;
   }
 
   private pushToDataLayer(data: DataLayerEvent): void {
     if (this.isClientSide() && globalThis.window.dataLayer) {
-      window.dataLayer.push(data);
+      globalThis.window.dataLayer.push(data);
     }
   }
 
@@ -145,13 +150,13 @@ class AnalyticsService {
 
     const callback = () => {
       if (url) {
-        window.location.href = url;
+        globalThis.window.location.href = url;
       }
     };
 
-    if (this.isClientSide() && window.gtag && this.sendTo.length > 0) {
+    if (this.isClientSide() && globalThis.window.gtag && this.sendTo.length > 0) {
       this.sendTo.forEach((target) => {
-        window.gtag('event', elementConversion, {
+        globalThis.window.gtag('event', elementConversion, {
           send_to: `${target}/${tag}`,
           value,
           currency,


### PR DESCRIPTION
This PR Modifies the constructor of ga.services to accept both single string and array of strings
- Updated SEND_TO constant to filter out undefined values with type predicate
- Refactored handleAdsConversion to iterate over multiple targets
- Ensured type safety by filtering and casting sendTo parameter correctly

This change enables tracking events to multiple Google Analytics properties simultaneously.


We need a new env variable @xabg2 