### PR TITLE
[MKT-667]:feat/update add_to_cart send_to to target both GA4 and Ads

### DIFF
--- a/src/services/ga.services.ts
+++ b/src/services/ga.services.ts
@@ -179,36 +179,22 @@ class AnalyticsService {
     const event = this.createEcommerceEvent('view_item', params);
     this.pushToDataLayer(event);
   }
+
   addToCart(params: PlanDetails): void {
-    const { planId, planPrice, currency, planType, interval, storage, promoCodeId } = params;
+    const standardEvent = this.createEcommerceEvent('add_to_cart', params);
+    this.pushToDataLayer(standardEvent);
 
-    const sendToTargets = this.sendTo.map((target) => {
-      return target === GA_ID ? `${target}/${CONVERSION_TAG}` : target;
-    });
+    if (this.isClientSide() && globalThis.window.gtag && GA_ID) {
+      const item = this.createEcommerceItem(params);
+      const conversionTarget = `${GA_ID}/${CONVERSION_TAG}`;
 
-    const event = {
-      event: 'add_to_cart',
-      send_to: sendToTargets,
-      ecommerce: {
-        value: formatPrice(planPrice),
-        currency: currency ?? this.defaultCurrency,
-        items: [
-          {
-            item_id: planId,
-            item_name: `${storage} ${capitalizeFirstLetter(interval)} Plan`,
-            item_brand: BRAND,
-            item_category: getPlanCategory(planType),
-            item_variant: interval,
-            currency: currency ?? this.defaultCurrency,
-            price: formatPrice(planPrice),
-            quantity: DEFAULT_QUANTITY,
-            ...(promoCodeId && { coupon: promoCodeId }),
-          },
-        ],
-      },
-    };
-
-    this.pushToDataLayer(event);
+      globalThis.window.gtag('event', 'add_to_cart', {
+        send_to: conversionTarget,
+        value: formatPrice(params.planPrice),
+        currency: params.currency ?? this.defaultCurrency,
+        items: [item],
+      });
+    }
   }
 
   purchase(params: PurchaseParams): void {

--- a/src/services/ga.services.ts
+++ b/src/services/ga.services.ts
@@ -184,12 +184,13 @@ class AnalyticsService {
     const standardEvent = this.createEcommerceEvent('add_to_cart', params);
     this.pushToDataLayer(standardEvent);
 
-    if (this.isClientSide() && globalThis.window.gtag && GA_ID) {
+    if (this.isClientSide() && globalThis.window.gtag) {
       const item = this.createEcommerceItem(params);
-      const conversionTarget = `${GA_ID}/${CONVERSION_TAG}`;
+
+      const sendToTargets = [GA_ID, `AW-728922855/${CONVERSION_TAG}`];
 
       globalThis.window.gtag('event', 'add_to_cart', {
-        send_to: conversionTarget,
+        send_to: sendToTargets,
         value: formatPrice(params.planPrice),
         currency: params.currency ?? this.defaultCurrency,
         items: [item],

--- a/src/services/ga.services.ts
+++ b/src/services/ga.services.ts
@@ -187,7 +187,7 @@ class AnalyticsService {
     if (this.isClientSide() && globalThis.window.gtag) {
       const item = this.createEcommerceItem(params);
 
-      const sendToTargets = [GA_ID, `AW-728922855/${CONVERSION_TAG}`];
+      const sendToTargets = [GA_CONTAINER, `${GA_ID}/${CONVERSION_TAG}`];
 
       globalThis.window.gtag('event', 'add_to_cart', {
         send_to: sendToTargets,


### PR DESCRIPTION
In this PR we change the way we send data after we received a specific requirement to ensure the add_to_cart event is sent explicitly to both Google Analytics 4 and Google Ads via the code. The send_to parameter needed to be formatted as an array containing both destination IDs to ensure proper data collection and attribution.