### PR TITLE
[MKT-678]:fix/redirect bf pages to avoid 404 on announces

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -234,7 +234,22 @@ module.exports = {
       },
       {
         source: '/black-friday',
-        destination: '/deals/black-friday-internxt',
+        destination: '/specialoffer',
+        permanent: false,
+      },
+      {
+        source: '/deals/black-friday-internxt',
+        destination: '/specialoffer',
+        permanent: false,
+      },
+      {
+        source: '/deals/black-friday-internxt/bf-cloud-storage-deals',
+        destination: '/specialoffer',
+        permanent: false,
+      },
+      {
+        source: '/deals/black-friday-internxt/bf-personal-cloud-storage-deals',
+        destination: '/specialoffer',
         permanent: false,
       },
       {


### PR DESCRIPTION
In this PR we redirect all the BF LPs to the specialOffer, this is because some advertisement still pointing to the BF LPs that don't exists anymore, with this solution we redirect the customers to a live LP