### PR TITLE
[MKT-685]:feat/Update Navbar, Cloud Data Centers UI, and Family page localization

### DIFF
--- a/src/assets/lang/es/cloud-data-centers.json
+++ b/src/assets/lang/es/cloud-data-centers.json
@@ -61,13 +61,13 @@
     }
   },
   "SecureCloudStorgaeSection": {
-    "title": "Almacenamiento seguro en la nube en centros de datos de clase mundial",
+    "title": "Almacenamiento en la nube en centros de datos de clase mundial",
     "description": "Internxt Drive ofrece todo lo que necesitas para asegurar\n que tus archivos y datos se mantengan privados con un\n almacenamiento en la nube seguro y más.",
     "card": {
       "title": "Internxt Drive",
       "description": [
         "Internxt Drive proporciona almacenamiento cifrado post-cuántico de extremo a extremo en centros de datos europeos que cumplen con los estándares de privacidad más estrictos. Tus archivos están protegidos con sistemas redundantes, controles ambientales y seguridad 24/7.",
-        "Mejora tu almacenamiento con Antivirus, VPN, Cleaner, Meet y Mail: tu *suite* de privacidad todo en uno para una protección total en línea."
+        "Mejora tu almacenamiento con Antivirus, VPN, Cleaner, Meet y Mail, suite de privacidad todo en uno para una protección total en línea."
       ],
       "cta": "Obtener Internxt"
     }

--- a/src/components/layout/components/navbar/ItemsNavigation.tsx
+++ b/src/components/layout/components/navbar/ItemsNavigation.tsx
@@ -30,7 +30,6 @@ interface ItemsNavigationProps {
     links: {
       pricing: string;
       about: string;
-      business: string;
     };
   };
   textContent: NavigationBarText;
@@ -121,13 +120,6 @@ export const ItemsNavigation = ({
             { href: 'https://ai.internxt.com/', text: textContent.products.ai },
           ]}
           darkMode={darkMode}
-          lang={lang}
-        />
-        <NavigationLink
-          href="/business"
-          text={textContent.links.business}
-          isActive={currentPath === getTitles.links.business.trim().toLowerCase()}
-          isDarkMode={darkMode}
           lang={lang}
         />
         <DropdownMenu

--- a/src/components/layout/navbars/Navbar.tsx
+++ b/src/components/layout/navbars/Navbar.tsx
@@ -307,20 +307,6 @@ export default function Navbar(props: Readonly<NavbarProps>) {
                           </>
                         )}
                       </Disclosure>
-                      <Link
-                        href="/business"
-                        locale={props.lang}
-                        role="link"
-                        tabIndex={0}
-                        onClick={() => {
-                          setMenuState(false);
-                        }}
-                        className={`flex w-full translate-y-0 px-8 py-4 outline-none transition delay-100 duration-300 ${
-                          menuState ? 'opacity-100' : '-translate-y-4 opacity-0'
-                        }`}
-                      >
-                        {props.textContent.links.business}
-                      </Link>
                       <Disclosure
                         as="div"
                         className={`flex w-screen translate-y-0 cursor-pointer flex-col outline-none transition delay-200 duration-300 ${

--- a/src/components/shared/ContentBlock.tsx
+++ b/src/components/shared/ContentBlock.tsx
@@ -9,14 +9,14 @@ export const ContentBlockSection = ({ textContent }: ContentBlockSectionProps) =
   return (
     <section className="flex items-center justify-between gap-6 bg-neutral-17 px-5 py-10 lg:px-10 lg:py-20 xl:p-32 3xl:px-80">
       <div
-        className="flex flex-col items-center justify-between gap-8 rounded-16 p-4 lg:p-0 lg:py-10 lg:pl-10"
+        className="flex flex-col items-center justify-between gap-10 rounded-16 p-4 lg:p-0 lg:py-10 lg:pl-10"
         style={{ background: 'linear-gradient(360deg, #E5EFFF 0%, #FFFFFF 100%' }}
       >
-        <p className="flex items-center text-center text-30  font-bold leading-tight text-gray-100 lg:pr-10 lg:text-4xl">
+        <p className="flex items-center text-center text-30 font-bold leading-tight text-gray-100 lg:pr-10 lg:text-4xl">
           {textContent.title}
         </p>
         <div className="flex flex-row items-center justify-between gap-10">
-          <div className="flex flex-col gap-6 lg:w-1/2 lg:gap-12">
+          <div className="flex flex-col gap-6 lg:w-1/2 lg:gap-6">
             <p className="flex text-base font-normal leading-tight text-gray-55 lg:whitespace-pre-line lg:text-xl">
               {textContent.description}
             </p>

--- a/src/pages/family.tsx
+++ b/src/pages/family.tsx
@@ -25,15 +25,23 @@ import { getImage } from '@/lib/getImage';
 import SelectFeatureInfoSection from '@/components/shared/components/SelectFeatureInfoSection';
 import { TextAndCardsGroupColumnSection } from '@/components/shared/components/TextAndCardsGroupColumnSection';
 import { PromoCodeName } from '@/lib/types';
+import { GetServerSidePropsContext } from 'next';
 
 interface FamilyProps {
+  lang: GetServerSidePropsContext['locale'];
   metatagsDescriptions: MetatagsDescription[];
   navbarText: NavigationBarText;
   textContent: FamilyText;
   footerText: FooterText;
 }
 
-export const FamilyLP = ({ metatagsDescriptions, navbarText, textContent, footerText }: FamilyProps): JSX.Element => {
+export const FamilyLP = ({
+  metatagsDescriptions,
+  navbarText,
+  textContent,
+  footerText,
+  lang,
+}: FamilyProps): JSX.Element => {
   const { products, loadingCards, currencyValue, businessCoupon } = usePricing({
     couponCodeForBusiness: PromoCodeName.BlackFriday,
   });
@@ -44,6 +52,7 @@ export const FamilyLP = ({ metatagsDescriptions, navbarText, textContent, footer
   const maxSecuritySection = textContent.MaximumSecuritySection;
   const selectInfoCard = textContent.WhatMakesInternxtPerfectSection.features;
   const cardsForGroupCardText = textContent.WhyChooseInternxt;
+  const locale = lang as string;
 
   const selectInfoCards = [
     {
@@ -114,7 +123,7 @@ export const FamilyLP = ({ metatagsDescriptions, navbarText, textContent, footer
 
   return (
     <Layout title={metatag.title} description={metatag.description}>
-      <Navbar fixed cta={['default']} lang="en" textContent={navbarText} />
+      <Navbar fixed cta={['default']} lang={locale} textContent={navbarText} />
 
       <HeroSection
         TextComponent={
@@ -159,7 +168,7 @@ export const FamilyLP = ({ metatagsDescriptions, navbarText, textContent, footer
 
       <PricingSectionWrapper
         loadingCards={loadingCards}
-        lang={'en'}
+        lang={locale}
         products={products}
         decimalDiscount={{
           business: businessCoupon?.percentOff && 100 - businessCoupon?.percentOff,
@@ -175,7 +184,7 @@ export const FamilyLP = ({ metatagsDescriptions, navbarText, textContent, footer
       <SelectFeatureInfoSection
         textContent={textContent.WhatMakesInternxtPerfectSection}
         cards={selectInfoCards}
-        lang="en"
+        lang={locale}
       />
 
       <CtaSection textContent={textContent.CtaSection} url={'#priceTable'} maxWidth="max-w-[500px]" />
@@ -213,7 +222,7 @@ export const FamilyLP = ({ metatagsDescriptions, navbarText, textContent, footer
       <TestimonialsSectionForBusiness textContent={textContent.TestimonialsSection} />
 
       <FAQSection textContent={textContent.FaqSection} />
-      <Footer lang="en" textContent={footerText} />
+      <Footer lang={locale} textContent={footerText} />
     </Layout>
   );
 };
@@ -221,10 +230,10 @@ export const FamilyLP = ({ metatagsDescriptions, navbarText, textContent, footer
 export async function getServerSideProps(ctx) {
   const lang = ctx.locale;
 
-  const metatagsDescriptions = require(`@/assets/lang/en/metatags-descriptions.json`);
-  const textContent = require(`@/assets/lang/en/family.json`);
-  const navbarText = require(`@/assets/lang/en/navbar.json`);
-  const footerText = require(`@/assets/lang/en/footer.json`);
+  const metatagsDescriptions = require(`@/assets/lang/${lang}/metatags-descriptions.json`);
+  const textContent = require(`@/assets/lang/${lang}/family.json`);
+  const navbarText = require(`@/assets/lang/${lang}/navbar.json`);
+  const footerText = require(`@/assets/lang/${lang}/footer.json`);
 
   return {
     props: {


### PR DESCRIPTION
This PR includes updates to the global navigation, UI refinements for the Cloud Data Centers component, and ensures the Family page is available across all supported languages.  
Changes 
- Navigation: Removed the "Business" option from the Navbar.  
- Cloud Data Centers Component: Updated Spanish copy for better clarity. Adjusted padding values for improved visual alignment.  
. Localization: Fixed an issue where the Family page was only rendering in English it is now accessible in all languages.
