### PR TITLE
[-]:fix/upgrade setup-node to v4 to fix engine incompatibility

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
This PR tries to resolve the build failure where the CI was detecting Node 18 instead of Node 22.

**Reason for change:**
The project requires `node >= 22.0.0` (defined in `package.json`), but `actions/setup-node@v1` is deprecated and does not support installing Node 22 properly, causing it to fall back to the default Node 18.