### PR TITLE
[MKT-750]:feat/Update Footer links & Fix PriceCard layout wrapping

### DIFF
--- a/src/assets/lang/de/footer.json
+++ b/src/assets/lang/de/footer.json
@@ -19,7 +19,7 @@
       "products": {
         "title": "Produkte",
         "drive": "Internxt Drive",
-        "objStorage": "Internxt S3",
+        "objStorage": "Internxt Enterprise S3",
         "antivirus": "Internxt Antivirus",
         "send": "Internxt Send",
         "vpn": "Internxt VPN",

--- a/src/assets/lang/de/navbar.json
+++ b/src/assets/lang/de/navbar.json
@@ -14,7 +14,7 @@
   },
   "products": {
     "drive": "Internxt Drive",
-    "s3": "Internxt S3",
+    "s3": "Cloud für Unternehmen",
     "webDAV": "Internxt WebDAV",
     "vpn": "Internxt VPN",
     "send": "Internxt Send",

--- a/src/assets/lang/en/footer.json
+++ b/src/assets/lang/en/footer.json
@@ -19,7 +19,7 @@
       "products": {
         "title": "Products",
         "drive": "Internxt Drive",
-        "objStorage": "Internxt S3",
+        "objStorage": "Internxt Enternprise S3",
         "antivirus": "Internxt Antivirus",
         "send": "Internxt Send",
         "vpn": "Internxt VPN",

--- a/src/assets/lang/en/navbar.json
+++ b/src/assets/lang/en/navbar.json
@@ -14,7 +14,7 @@
   },
   "products": {
     "drive": "Internxt Drive",
-    "s3": "Internxt S3",
+    "s3": "Enterprise Cloud Storage",
     "webDAV": "Internxt WebDAV",
     "vpn": "Internxt VPN",
     "send": "Internxt Send",

--- a/src/assets/lang/es/footer.json
+++ b/src/assets/lang/es/footer.json
@@ -19,7 +19,7 @@
       "products": {
         "title": "Productos",
         "drive": "Internxt Drive",
-        "objStorage": "Internxt S3",
+        "objStorage": "Internxt S3 para empresas",
         "antivirus": "Internxt Antivirus",
         "send": "Internxt Send",
         "vpn": "Internxt VPN",

--- a/src/assets/lang/es/navbar.json
+++ b/src/assets/lang/es/navbar.json
@@ -19,7 +19,7 @@
   },
   "products": {
     "drive": "Internxt Drive",
-    "s3": "Internxt S3",
+    "s3": "Cloud para Empresas",
     "webDAV": "Internxt WebDAV",
     "vpn": "Internxt VPN",
     "send": "Internxt Send",

--- a/src/assets/lang/fr/footer.json
+++ b/src/assets/lang/fr/footer.json
@@ -19,7 +19,7 @@
       "products": {
         "title": "Produits",
         "drive": "Internxt Drive",
-        "objStorage": "Internxt S3",
+        "objStorage": "Internxt S3 pour entreprises",
         "antivirus": "Internxt Antivirus",
         "send": "Internxt Send",
         "vpn": "Internxt VPN",

--- a/src/assets/lang/fr/navbar.json
+++ b/src/assets/lang/fr/navbar.json
@@ -19,7 +19,7 @@
   },
   "products": {
     "drive": "Internxt Drive",
-    "s3": "Internxt S3",
+    "s3": "Cloud pour entreprises",
     "webDAV": "Internxt WebDAV",
     "vpn": "Internxt VPN",
     "send": "Internxt Send",

--- a/src/assets/lang/it/footer.json
+++ b/src/assets/lang/it/footer.json
@@ -19,7 +19,7 @@
       "products": {
         "title": "Prodotti",
         "drive": "Internxt Drive",
-        "objStorage": "Internxt S3",
+        "objStorage": "Internxt S3 per le aziende",
         "antivirus": "Internxt Antivirus",
         "send": "Internxt Send",
         "vpn": "Internxt VPN",

--- a/src/assets/lang/it/navbar.json
+++ b/src/assets/lang/it/navbar.json
@@ -18,7 +18,7 @@
   },
   "products": {
     "drive": "Internxt Drive",
-    "s3": "Internxt S3",
+    "s3": "Cloud per le aziende",
     "webDAV": "Internxt WebDAV",
     "vpn": "Internxt VPN",
     "send": "Internxt Send",

--- a/src/assets/lang/ru/footer.json
+++ b/src/assets/lang/ru/footer.json
@@ -19,7 +19,7 @@
       "products": {
         "title": "Продукты",
         "drive": "Internxt Drive",
-        "objStorage": "Internxt S3",
+        "objStorage": "Internxt S3 для предприятий",
         "antivirus": "Internxt Antivirus",
         "send": "Internxt Send",
         "vpn": "Internxt VPN",

--- a/src/assets/lang/ru/navbar.json
+++ b/src/assets/lang/ru/navbar.json
@@ -18,7 +18,7 @@
   },
   "products": {
     "drive": "Internxt Drive",
-    "s3": "Internxt S3",
+    "s3": "Облако для предприятий",
     "webDAV": "Internxt WebDAV",
     "vpn": "Internxt VPN",
     "send": "Internxt Send",

--- a/src/assets/lang/zh-tw/footer.json
+++ b/src/assets/lang/zh-tw/footer.json
@@ -19,7 +19,7 @@
       "products": {
         "title": "產品",
         "drive": "Internxt Drive (雲碟)",
-        "objStorage": "Internxt S3 (物件儲存)",
+        "objStorage": "Internxt 企業級 S3 (物件儲存)",
         "antivirus": "Internxt Antivirus (防毒軟體)",
         "send": "Internxt Send (發送)",
         "vpn": "Internxt VPN (虛擬私人網路)",

--- a/src/assets/lang/zh-tw/navbar.json
+++ b/src/assets/lang/zh-tw/navbar.json
@@ -14,7 +14,7 @@
   },
   "products": {
     "drive": "Internxt Drive",
-    "s3": "Internxt S3",
+    "s3": "企業雲",
     "webDAV": "Internxt WebDAV",
     "send": "Internxt Send",
     "vpn": "Internxt VPN",

--- a/src/assets/lang/zh/footer.json
+++ b/src/assets/lang/zh/footer.json
@@ -19,7 +19,7 @@
       "products": {
         "title": "产品",
         "drive": "Internxt Drive (云盘)",
-        "objStorage": "Internxt S3 (对象存储)",
+        "objStorage": "Internxt 企业级 S3 (对象存储)",
         "antivirus": "Internxt Antivirus (杀毒软件)",
         "send": "Internxt Send (发送)",
         "vpn": "Internxt VPN (虚拟私人网络)",

--- a/src/assets/lang/zh/navbar.json
+++ b/src/assets/lang/zh/navbar.json
@@ -14,7 +14,7 @@
   },
   "products": {
     "drive": "Internxt Drive",
-    "s3": "Internxt S3",
+    "s3": "企业云",
     "webDAV": "Internxt WebDAV",
     "vpn": "Internxt VPN",
     "send": "Internxt Send",

--- a/src/components/layout/components/navbar/ItemsNavigation.tsx
+++ b/src/components/layout/components/navbar/ItemsNavigation.tsx
@@ -122,6 +122,15 @@ export const ItemsNavigation = ({
           darkMode={darkMode}
           lang={lang}
         />
+
+        <NavigationLink
+          href="/cloud-object-storage"
+          text={textContent.products.s3}
+          isActive={currentPath === getTitles.links.pricing.trim().toLowerCase()}
+          isDarkMode={darkMode}
+          lang={lang}
+        />
+
         <DropdownMenu
           label={textContent.links.ourValues}
           items={[

--- a/src/components/layout/footers/Footer.tsx
+++ b/src/components/layout/footers/Footer.tsx
@@ -18,7 +18,6 @@ export default function Footer({
   lang,
   hideNewsletter,
   darkMode,
-  needsH2 = true,
 }: Readonly<{
   textContent: FooterText;
   lang: string;
@@ -186,15 +185,6 @@ export default function Footer({
                     </Link>
 
                     <Link
-                      href="/cloud-object-storage"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="flex flex-row items-center hover:text-primary"
-                    >
-                      <div className="flex flex-row">{textContent.FooterSection.sections.products.objStorage}</div>
-                    </Link>
-
-                    <Link
                       href="/antivirus"
                       target="_blank"
                       rel="noreferrer"
@@ -264,22 +254,14 @@ export default function Footer({
                         {textContent.FooterSection.new}
                       </span>
                     </Link>
-                    <Link
-                      href="/business"
-                      locale={'en'}
-                      passHref
-                      className="flex max-w-[250px] items-center hover:text-primary"
-                    >
-                      {textContent.FooterSection.sections.products.business}
-                    </Link>
 
                     <Link
-                      href="/family"
-                      locale={'en'}
-                      passHref
-                      className="flex max-w-[250px] items-center hover:text-primary"
+                      href="/cloud-object-storage"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="flex flex-row items-center hover:text-primary"
                     >
-                      {textContent.FooterSection.sections.products.family}
+                      <div className="flex flex-row">{textContent.FooterSection.sections.products.objStorage}</div>
                     </Link>
 
                     <Link href="/pricing" locale={lang} passHref className="hover:text-primary">
@@ -866,14 +848,7 @@ export default function Footer({
                           <p>{textContent.FooterSection.sections.products.drive}</p>
                         </div>
                       </Link>
-                      <Link
-                        href="/cloud-object-storage"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="flex flex-row items-center hover:text-primary"
-                      >
-                        {textContent.FooterSection.sections.products.objStorage}
-                      </Link>
+
                       <Link
                         href="/antivirus"
                         target="_blank"
@@ -909,12 +884,16 @@ export default function Footer({
                       >
                         {textContent.FooterSection.sections.products.ai}
                       </Link>
-                      <Link href="/business" locale={lang} passHref className="items-center hover:text-primary">
-                        {textContent.FooterSection.sections.products.business}
+
+                      <Link
+                        href="/cloud-object-storage"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex flex-row items-center hover:text-primary"
+                      >
+                        {textContent.FooterSection.sections.products.objStorage}
                       </Link>
-                      <Link href="/family" locale={lang} passHref className="items-center hover:text-primary">
-                        {textContent.FooterSection.sections.products.family}
-                      </Link>
+
                       <Link href="/pricing" locale={lang} passHref className="items-center hover:text-primary">
                         {textContent.FooterSection.sections.products.pricing}
                       </Link>
@@ -1363,12 +1342,6 @@ export default function Footer({
                       </Link>
                       <Link href="/ai-detector" locale={lang} passHref>
                         {textContent.FooterSection.sections.tools.aiDetector}
-                      </Link>
-                      <Link href="/business" locale={lang} passHref className="hover:text-primary">
-                        {textContent.FooterSection.sections.products.business}
-                      </Link>
-                      <Link href="/family" locale={lang} passHref className="hover:text-primary">
-                        {textContent.FooterSection.sections.products.family}
                       </Link>
                       <Link href="/pricing" locale={lang} passHref className="hover:text-primary">
                         {textContent.FooterSection.sections.products.pricing}

--- a/src/components/layout/navbars/Navbar.tsx
+++ b/src/components/layout/navbars/Navbar.tsx
@@ -307,6 +307,20 @@ export default function Navbar(props: Readonly<NavbarProps>) {
                           </>
                         )}
                       </Disclosure>
+                      <Link
+                        href="/cloud-object-storage"
+                        locale={props.lang}
+                        role="link"
+                        tabIndex={0}
+                        onClick={() => {
+                          setMenuState(false);
+                        }}
+                        className={`flex w-full translate-y-0 px-8 py-4 outline-none transition delay-100 duration-300 ${
+                          menuState ? 'opacity-100' : '-translate-y-4 opacity-0'
+                        }`}
+                      >
+                        {props.textContent.products.s3}
+                      </Link>
                       <Disclosure
                         as="div"
                         className={`flex w-screen translate-y-0 cursor-pointer flex-col outline-none transition delay-200 duration-300 ${

--- a/src/components/shared/pricing/PricingSection.tsx
+++ b/src/components/shared/pricing/PricingSection.tsx
@@ -187,7 +187,7 @@ export const PricingSection = ({
         enterTo="scale-100 translate-y-0 opacity-100"
         className="flex flex-col gap-4"
       >
-        <div className="content flex w-full flex-wrap items-stretch justify-center gap-6">
+        <div className="content flex w-full flex-nowrap items-stretch justify-start gap-6 overflow-x-auto pb-8 md:justify-center">
           {products?.individuals
             ? products.individuals[billingFrequency]
                 .filter((product) => {

--- a/src/pages/[filename].tsx
+++ b/src/pages/[filename].tsx
@@ -202,7 +202,7 @@ function CombinedSpecialOffer({
 
       <FloatingCtaSectionv2
         textContent={langJson.ctaSection}
-        url={'/pricing'}
+        url={'#billingButtons'}
         customText={renderCtaContent(
           langJson.ctaSection.title,
           langJson.ctaSection.description,
@@ -222,7 +222,7 @@ function CombinedSpecialOffer({
 
       <FloatingCtaSectionv2
         textContent={langJson.ctaSection2}
-        url={'/pricing'}
+        url={'#billingButtons'}
         customText={renderCtaContent(
           langJson.ctaSection2.title,
           langJson.ctaSection2.description,


### PR DESCRIPTION
This PR updates the navigation links in the Footer and improves the UI layout for PriceCards in specific locales.

Key changes
- Navbar:
Added link to Cloud Object Storage LP.
-Footer
Removed links to Business and Family pages.

Improved SEO attributes for Navbar and Footer components

Solved a layout issue where PriceCards in French wrapped to two lines. They now stay on a single line.