### PR TITLE
[PB-6055]: Add Cello referral attribution to special offer pages

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -265,6 +265,14 @@ export function checkout({ planId, promoCodeId, planType, mode, currency, gclid 
     mode && params.set('mode', mode ? mode : 'subscription');
     gclid && params.set('gclid', gclid);
 
+    const currentParams = new URLSearchParams(globalThis.location.search);
+    const celloProductId = currentParams.get('productId');
+    const celloUcc = currentParams.get('ucc');
+    const celloN = currentParams.get('celloN');
+    if (celloProductId) params.set('productId', celloProductId);
+    if (celloUcc) params.set('ucc', celloUcc);
+    if (celloN) params.set('celloN', celloN);
+
     window.location.href = AUTH_FLOW_URL + `${pathname}?${params.toString()}`;
   }
 

--- a/src/pages/specialoffer.tsx
+++ b/src/pages/specialoffer.tsx
@@ -1,4 +1,5 @@
 import Layout from '@/components/layout/Layout';
+import Script from 'next/script';
 
 import { PromoCodeName } from '@/lib/types';
 import Footer from '@/components/layout/footers/Footer';
@@ -83,6 +84,7 @@ function SpecialOffer({
 
   return (
     <Layout title={metatags[0].title} description={metatags[0].description} segmentName="Partners" lang={lang}>
+      <Script src={process.env.NEXT_PUBLIC_CELLO_ATTRIBUTION_URL} type="module" strategy="afterInteractive" />
       <Navbar lang={lang} textContent={navbarLang} cta={['payment']} isLinksHidden hideCTA />
 
       <HeroSection textContent={langJson.HeroSection} percentOff={percentOff} image={'internxt-private-cloud'} />

--- a/src/pages/specialoffer/[filename].tsx
+++ b/src/pages/specialoffer/[filename].tsx
@@ -2,6 +2,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Layout from '@/components/layout/Layout';
+import Script from 'next/script';
 import { PromoCodeName } from '@/lib/types';
 import Footer from '@/components/layout/footers/Footer';
 import usePricing from '@/hooks/usePricing';
@@ -39,7 +40,7 @@ const ALLOWED_PATHS = [
   'love',
 ];
 
-const ALTERNATE_RECOMENDATED_PLAN_PATHS = ['grabon', 'kripesh','rclone'];
+const ALTERNATE_RECOMENDATED_PLAN_PATHS = ['grabon', 'kripesh', 'rclone'];
 const DARK_MODE_PATHS = ['baity'];
 
 const COUPON_CODES = {
@@ -147,6 +148,7 @@ function CombinedSpecialOffer({
       lang={lang}
       robots="noindex, follow"
     >
+      <Script src={process.env.NEXT_PUBLIC_CELLO_ATTRIBUTION_URL} type="module" strategy="afterInteractive" />
       <Navbar lang={lang} textContent={navbarLang} cta={['payment']} isLinksHidden hideLogoLink hideCTA />
 
       <HeroSection


### PR DESCRIPTION
Forward Cello query params (productId, ucc, celloN) from the landing page URL to the checkout redirect, and embed the Cello attribution script on special offer pages for referral personalization banner.