### PR TITLE
[-]:fix/patch stack overflow vulnerability

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -213,11 +213,6 @@ module.exports = {
         permanent: false,
       },
       {
-        source: '/driffle',
-        destination: '/redeem/driffle',
-        permanent: false,
-      },
-      {
         source: '/special-offer/:filename',
         destination: '/specialoffer/:filename',
         permanent: false,

--- a/package.json
+++ b/package.json
@@ -110,6 +110,10 @@
   },
   "resolutions": {
     "**/js-yaml": "^4.1.1",
+    "@emotion/react/**/yaml": "1.10.3",
+    "@emotion/styled/**/yaml": "1.10.3",
+    "@svgr/webpack/**/yaml": "1.10.3",
+    "react-select/**/yaml": "1.10.3",
     "nyc": "^17.1.0",
     "form-data": "^4.0.4",
     "tar": "^7.5.7",

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -11,7 +11,7 @@ import { signup } from '@/lib/auth';
 interface SignUpProps {
   textContent: any;
   loading?: boolean;
-  provider?: 'STACKCOMMERCE' | 'TECHCULT' | 'DEALMIRROR' | 'MIGHTYDEALS' | 'OYSTERVPN' | 'COINGATE' | 'DRIFFLE';
+  provider?: 'STACKCOMMERCE' | 'TECHCULT' | 'DEALMIRROR' | 'MIGHTYDEALS' | 'OYSTERVPN' | 'COINGATE' ;
 }
 
 export default function SignUp(props: Readonly<SignUpProps>) {

--- a/src/components/home/TrustedSection.tsx
+++ b/src/components/home/TrustedSection.tsx
@@ -59,7 +59,7 @@ export default function TrustedSection({
   return (
     <section
       ref={sectionRef}
-      className={`flex h-full w-full flex-col items-start justify-start overflow-hidden px-8 py-10 lg:h-min lg:items-center lg:justify-center lg:gap-20 lg:pb-28 ${
+      className={`flex h-full w-full flex-col items-start justify-start overflow-hidden px-8 py-10 lg:h-min lg:items-center lg:justify-center lg:gap-20 lg:pb-28 lg:px-10 xl:px-32 3xl:px-80 ${
         darkMode ? 'bg-[#1C1C1C]' : ''
       }`}
       style={
@@ -73,7 +73,7 @@ export default function TrustedSection({
       {bottomBar && (
         <div className="absolute bottom-0 left-8 right-8 h-[1px] bg-neutral-35 lg:bottom-0 lg:left-32 lg:right-32"></div>
       )}
-      <p className="flex w-[1280px] flex-wrap font-semibold text-[60px] leading-[100%] py-1 gap-x-[0.35em]">
+      <p className="w-full font-semibold text-[60px] leading-[100%] py-1 text-justify">
         {groups.map((group, i) => (
           <span
             key={i}
@@ -85,7 +85,7 @@ export default function TrustedSection({
               transition: 'color 0.4s ease',
             }}
           >
-            {group}
+            {i > 0 ? ' ' : ''}{group}
           </span>
         ))}
       </p>

--- a/src/pages/redeem/[filename].tsx
+++ b/src/pages/redeem/[filename].tsx
@@ -21,7 +21,7 @@ interface RedeemPageProps {
   lang: string;
 }
 
-const ALLOWED_PATHS = ['stackcommerce', 'coingate', 'driffle'];
+const ALLOWED_PATHS = ['stackcommerce', 'coingate'];
 
 const SpecialOfferPage = ({
   metatagsDescriptions,
@@ -48,7 +48,7 @@ const SpecialOfferPage = ({
     setOpenDialog(true);
   };
 
-  const ALLOWED_PROVIDERS = ['STACKCOMMERCE', 'COINGATE', 'DRIFFLE'] as const;
+  const ALLOWED_PROVIDERS = ['STACKCOMMERCE', 'COINGATE'] as const;
 
   type Provider = typeof ALLOWED_PROVIDERS[number];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9420,10 +9420,10 @@ yallist@^5.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
-yaml@^1.10.0:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+yaml@1.10.3, yaml@^1.10.0:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yaml@^2.3.4:
   version "2.5.0"


### PR DESCRIPTION
Adds Yarn resolutions to force yaml@1.10.3 for the four packages that transitively pull in the vulnerable yaml@1.x:
- @emotion/react
- @emotion/styled
- @svgr/webpack
- react-select
