### PR TITLE
[-]:feat/allow precharge of GTM

### DIFF
--- a/public/js/cookiebanner.script.js
+++ b/public/js/cookiebanner.script.js
@@ -156,16 +156,6 @@ var t = translations[lang];
 
 var headerScripts = [
   {
-    title: 'Google Tag Manager',
-    type: 'analytics',
-    value:
-      "<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':\n" +
-      "new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],\n" +
-      "j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=\n" +
-      "'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);\n" +
-      "})(window,document,'script','dataLayer','GTM-P7N7LW5G');</script>",
-  },
-  {
     title: 'Google Analytics',
     type: 'analytics',
     value:
@@ -276,6 +266,20 @@ var injectScripts = function () {
   appendScriptInHead('analytics');
   appendScriptInHead('marketing');
   appendScriptInHead('preferences');
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){window.dataLayer.push(arguments);}
+  var prefsStr = n('cookieConsentPrefs');
+  var prefs = prefsStr ? JSON.parse(prefsStr) : [];
+  var isAnalytics = prefs.indexOf('analytics') !== -1;
+  var isMarketing = prefs.indexOf('marketing') !== -1;
+
+  gtag('consent', 'update', {
+    'analytics_storage': isAnalytics ? 'granted' : 'denied',
+    'ad_storage': isMarketing ? 'granted' : 'denied',
+    'ad_user_data': isMarketing ? 'granted' : 'denied',
+    'ad_personalization': isMarketing ? 'granted' : 'denied'
+  });
 };
 
 !(function (e) {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -122,19 +122,6 @@ export default function Layout({
         ></style>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" />
 
-        {/*Internxt Pixel 
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-CHHGLQTHSB"></script>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('js', new Date());
-              gtag('config', 'G-CHHGLQTHSB');
-            `,
-          }}
-        />*/}
-
         {/*Cookies Banner */}
         <script
           dangerouslySetInnerHTML={{

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect } from 'react';
 import { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
+import Script from 'next/script';
 import { Intercom, LiveChatLoaderProvider } from 'react-live-chat-loader';
 import 'react-tooltip/dist/react-tooltip.css';
 import '@/styles/globals.scss';
@@ -81,6 +82,30 @@ function MyApp({ Component, pageProps }: AppProps) {
           },
         ]}
       >
+        <Script
+          id="gtm-script"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){window.dataLayer.push(arguments);}
+              gtag('consent', 'default', {
+                'ad_storage': 'denied',
+                'analytics_storage': 'denied',
+                'ad_user_data': 'denied',
+                'ad_personalization': 'denied',
+                'wait_for_update': 500
+              });
+              gtag('set', 'ads_data_redaction', true);
+
+              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+              })(window,document,'script','dataLayer','GTM-P7N7LW5G');
+            `,
+          }}
+        />
         <noscript>
           <iframe
             src="https://www.googletagmanager.com/ns.html?id=GTM-P7N7LW5G"


### PR DESCRIPTION
Refactored the cookie banner to resolve tracking data loss caused by dynamic injection. Google Tag Manager (GTM) is now pre-loaded with a default 'denied' consent state, ensuring no data access until user validation. This implementation follows [Google’s technical guidelines](https://developers.google.com/tag-platform/security/guides/consent?hl=es&consentmode=advanced) for GDPR-compliant Consent Mode.