### PR TITLE
[MKT-907]fix/Fix Loss of UTM/gclid attribution

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -178,7 +178,7 @@ const prepareAuthFlow = (credentials: {
 
   const cookie = `cr=${btoa(JSON.stringify(payload))};expires=${new Date(
     expiration,
-  ).toUTCString()};domain=internxt.com; Path=/`;
+  ).toUTCString()};domain=.internxt.com; Path=/`;
 
   document.cookie = cookie;
 };

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -14,11 +14,15 @@ const TRACKING_PARAMS = [
   'utm_source',
   'utm_campaign',
   'utm_id',
+  'utm_term',
+  'utm_content',
   'gclid',
   'irclickid',
   'gad_source',
   'gad_campaignid',
-  'gbraid'
+  'gbraid',
+  '_fbp',
+  '_fbc'
 ] as const;
 
 function parseUri(ctx: GetServerSidePropsContext) {

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -13,14 +13,12 @@ const TRACKING_PARAMS = [
   'utm_medium',
   'utm_source',
   'utm_campaign',
-  'utm_name',
   'utm_id',
   'gclid',
   'irclickid',
-  'ga_campaign',
-  'ga_adgroup',
-  'ga_keyword',
-  'ga_network',
+  'gad_source',
+  'gad_campaignid',
+  'gbraid'
 ] as const;
 
 function parseUri(ctx: GetServerSidePropsContext) {


### PR DESCRIPTION
the link of google ads includes parameters like gad_source, gad_campaignid and others, so i removed unused parameters and collect new parameters as well and store them in the cookies.