### PR TITLE
[MKT-914]fix/Overlaps of logo

### DIFF
--- a/src/components/layout/components/navbar/ItemsNavigation.tsx
+++ b/src/components/layout/components/navbar/ItemsNavigation.tsx
@@ -40,7 +40,7 @@ interface ItemsNavigationProps {
 }
 
 const getLinkClasses = (isDarkMode: boolean, isActive: boolean) => {
-  const baseClasses = 'whitespace-nowrap px-4 py-1.5 text-base font-medium transition duration-150 ease-in-out';
+  const baseClasses = 'px-4 py-1.5 text-base min-[1024px]:text-sm min-[1100px]:text-base font-medium transition duration-150 ease-in-out';
   const darkModeClasses = isDarkMode ? 'text-white hover:text-gray-20' : 'text-gray-60 hover:text-primary';
 
   return `${baseClasses} ${isActive ? 'text-primary' : darkModeClasses}`;
@@ -63,7 +63,7 @@ const DropdownMenu = ({ label, items, darkMode, lang }: DropdownMenuProps) => {
 
   return (
     <div
-      className={`group relative flex cursor-default items-center space-x-1 rounded-lg px-4 py-1.5 pr-2 font-medium transition duration-150 ease-in-out ${menuClasses}`}
+      className={`group relative flex cursor-default items-center space-x-1 min-[1024px]:text-sm min-[1100px]:text-base rounded-lg px-4 py-1.5 pr-2 font-medium transition duration-150 ease-in-out ${menuClasses}`}
     >
       <span>{label}</span>
       <CaretDown
@@ -130,9 +130,7 @@ export const ItemsNavigation = ({
             { href: '/antivirus', text: textContent.products.antivirus },
             { href: '/vpn', text: textContent.products.vpn },
             { href: '/cleaner', text: textContent.products.cleaner },
-            { href: '/meet', text: textContent.products.meet },
-            { href: 'https://ai.internxt.com/', text: textContent.products.ai },
-            { href: 'https://send.internxt.com/', text: textContent.products.send },
+            { href: '/meet', text: textContent.products.meet }
           ]}
           darkMode={darkMode}
           lang={lang}

--- a/src/components/layout/footers/Footer.tsx
+++ b/src/components/layout/footers/Footer.tsx
@@ -74,7 +74,7 @@ export default function Footer({
       className={`flex w-full flex-col overflow-hidden  ${darkMode ? 'bg-[#1C1C1C] text-white' : ''}`}
     >
       <div
-        className="flex w-full flex-col items-center justify-center pt-10 sm:py-12 lg:px-10 lg:pt-10 xl:px-32 3xl:px-80"
+        className="flex w-full flex-col items-center justify-center pt-10 sm:py-12 lg:px-10 lg:pt-10 xl:px-32 3xl:px-56"
         style={{ background: darkMode ? '' : 'linear-gradient(180deg, #FFFFFF 0%, #E5EFFF 100%)' }}
       >
         <div className={`w-full bg-green-120 ${darkMode ? 'bg-cool-gray-90' : 'bg-cool-gray-10'} h-[1px] lg:mb-10`} />
@@ -86,7 +86,7 @@ export default function Footer({
         )}
 
         <div className="flex w-full flex-col gap-6 p-6 lg:flex-row lg:justify-between lg:gap-8 lg:p-0">
-          <div className="flex w-full flex-row items-end gap-6 lg:w-1/3 2xl:w-[40%]">
+          <div className="flex w-full flex-row items-end gap-6 lg:w-[48%] xl:w-[43%] 2xl:w-[35%]">
             <div className="flex flex-col items-start justify-between gap-9 flex-1">
               <div className="flex flex-col gap-2">
                 <p className="text-lg font-medium">{textContent.DownloadApp.title}</p>


### PR DESCRIPTION
1. Fixed the overlap of logo of internxt with ItemNavigation by reducing the text size when width of viewport is minor then 1100px.
2. Seperate the qr code from the application store block by defining the percentage of occupation of the block for different size of sreen.
3. Removed the ai and send link from the product tab of navbar.

navbar original:
<img width="1920" height="1080" alt="original" src="https://github.com/user-attachments/assets/028a8572-37cc-49da-9f50-0068c34fcbc7" />
navbar cambiado:
<img width="1920" height="1080" alt="cambiado" src="https://github.com/user-attachments/assets/72d15552-8fef-46a5-9c1c-2579c706790f" />
footer original:
<img width="1920" height="1080" alt="originalfooter" src="https://github.com/user-attachments/assets/2cde1a6b-c6b5-4687-86bc-e98db55ed092" />
footer cambiado:
<img width="1920" height="1080" alt="cambiadoFooter" src="https://github.com/user-attachments/assets/f52e8d69-0969-4d89-bc43-5f95a11213e6" />
product tab:
<img width="349" height="334" alt="productTab" src="https://github.com/user-attachments/assets/09b661b5-da18-42c4-a289-809b1d904fae" />

