### PR TITLE
[_]:feat/improve coupon use in PPC LPs

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,5 +4,6 @@ Disallow: /child-safety-book
 Disallow: /use-cases
 Disallow: /internxt-library
 Disallow: /online-privacy-ebook
+Disallow: /ppc
 Sitemap: https://internxt.com/sitemap.xml
 Sitemap: https://internxt.com/sitemap-top-urls.xml

--- a/src/hooks/usePpcCoupon.ts
+++ b/src/hooks/usePpcCoupon.ts
@@ -1,0 +1,24 @@
+import { useRouter } from 'next/router';
+import { PromoCodeName } from '@/lib/types';
+
+type PpcCoupons = {
+  couponCode: PromoCodeName;
+  couponCodeForLifetime: PromoCodeName;
+};
+
+function usePpcCoupon({ couponCode, couponCodeForLifetime }: PpcCoupons): PpcCoupons {
+  const router = useRouter();
+  const { fbclid, gclid, utm_source: utmSource } = router.query;
+
+  if (fbclid) {
+    return { couponCode: PromoCodeName.META85, couponCodeForLifetime: PromoCodeName.META85 };
+  }
+
+  if (gclid || utmSource === 'google') {
+    return { couponCode: PromoCodeName.GADS85, couponCodeForLifetime: PromoCodeName.GADS85 };
+  }
+
+  return { couponCode, couponCodeForLifetime };
+}
+
+export default usePpcCoupon;

--- a/src/pages/ppc/drive.tsx
+++ b/src/pages/ppc/drive.tsx
@@ -25,7 +25,7 @@ import { PromoCodeName } from '@/lib/types';
 import { stripeService } from '@/services/stripe.service';
 import { sm_breadcrumb } from '@/components/utils/schema-markup-generator';
 import Script from 'next/script';
-import { useRouter } from 'next/router';
+import usePpcCoupon from '@/hooks/usePpcCoupon';
 
 interface DriveProps {
   textContent: DriveText;
@@ -56,8 +56,10 @@ const Drive = ({
   relationalLinksText,
 }: DriveProps): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'drive');
-  const router = useRouter();
-  const ppcCoupon = router.query.utm_source === 'google' ? PromoCodeName.GADS85 : PromoCodeName.META85;
+  const ppcCoupon = usePpcCoupon({
+    couponCode: PromoCodeName.OFFSUB,
+    couponCodeForLifetime: PromoCodeName.OFFLFT,
+  });
   const {
     products,
     loadingCards,
@@ -65,10 +67,7 @@ const Drive = ({
     coupon: individualCoupon,
     lifetimeCoupon: lifetimeCoupon,
     lifetimeCoupons,
-  } = usePricing({
-    couponCode: ppcCoupon,
-    couponCodeForLifetime: ppcCoupon,
-  });
+  } = usePricing(ppcCoupon);
 
   const onCheckoutButtonClicked = async (
     priceId: string,
@@ -106,7 +105,13 @@ const Drive = ({
       <Script type="application/ld+json" strategy="beforeInteractive">
         {sm_breadcrumb('Secure cloud storage', 'drive')}
       </Script>
-      <Layout title={metatags[0].title} description={metatags[0].description} segmentName="Drive" lang={lang}>
+      <Layout
+        title={metatags[0].title}
+        description={metatags[0].description}
+        segmentName="PPC Drive"
+        lang={lang}
+        robots="noindex, follow"
+      >
         <Navbar textContent={navbarLang} lang={lang} cta={['default']} fixed />
         <HeroSection textContent={textContent.HeroSection} download={download} />
 

--- a/src/pages/ppc/index.tsx
+++ b/src/pages/ppc/index.tsx
@@ -1,5 +1,5 @@
 import { GetServerSidePropsContext } from 'next';
-import { useRouter } from 'next/router';
+import usePpcCoupon from '@/hooks/usePpcCoupon';
 import { HomeText } from '@/assets/types/home';
 import { FooterText, MetatagsDescription, NavigationBarText } from '@/assets/types/layout/types';
 import HeroSection from '@/components/home/HeroSection';
@@ -28,8 +28,10 @@ interface HomeProps {
 
 const HomePage = ({ metatagsDescriptions, textContent, lang, navbarLang, footerLang }: HomeProps): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'home');
-  const router = useRouter();
-  const ppcCoupon = router.query.utm_source === 'google' ? PromoCodeName.GADS85 : PromoCodeName.META85;
+  const ppcCoupon = usePpcCoupon({
+    couponCode: PromoCodeName.OFFSUB,
+    couponCodeForLifetime: PromoCodeName.OFFLFT,
+  });
 
   const {
     products,
@@ -38,10 +40,7 @@ const HomePage = ({ metatagsDescriptions, textContent, lang, navbarLang, footerL
     coupon: individualCoupon,
     lifetimeCoupon: lifetimeCoupon,
     lifetimeCoupons,
-  } = usePricing({
-    couponCode: ppcCoupon,
-    couponCodeForLifetime: ppcCoupon,
-  });
+  } = usePricing(ppcCoupon);
   const locale = lang as string;
   const navbarCta = 'chooseStorage';
 
@@ -81,7 +80,13 @@ const HomePage = ({ metatagsDescriptions, textContent, lang, navbarLang, footerL
     : products?.individuals[Interval.Year][0].price.toString() || '9.99';
 
   return (
-    <Layout title={metatags[0].title} description={metatags[0].description} segmentName="Home" lang={lang}>
+    <Layout
+      title={metatags[0].title}
+      description={metatags[0].description}
+      segmentName="PPC Home"
+      lang={lang}
+      robots="noindex, follow"
+    >
       <Navbar textContent={navbarLang} lang={locale} cta={[navbarCta]} fixed />
 
       <HeroSection textContent={textContent.HeroSection} percentOff={percentOff} minimumPrice={minimumPrice} />

--- a/src/pages/ppc/mega-alternative.tsx
+++ b/src/pages/ppc/mega-alternative.tsx
@@ -15,13 +15,15 @@ import { HeroSection } from '@/components/comparison/HeroSection';
 import Footer from '@/components/layout/footers/Footer';
 import { sm_breadcrumb } from '@/components/utils/schema-markup-generator';
 import Script from 'next/script';
-import { useRouter } from 'next/router';
+import usePpcCoupon from '@/hooks/usePpcCoupon';
 
 const MegaComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, footerLang }): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'mega-alternative');
 
-  const router = useRouter();
-  const ppcCoupon = router.query.utm_source === 'google' ? PromoCodeName.GADS85 : PromoCodeName.META85;
+  const ppcCoupon = usePpcCoupon({
+    couponCode: PromoCodeName.Mega85,
+    couponCodeForLifetime: PromoCodeName.Mega85,
+  });
 
   const {
     products,
@@ -30,10 +32,7 @@ const MegaComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, foot
     coupon: individualCoupon,
     lifetimeCoupon: lifetimeCoupon,
     lifetimeCoupons,
-  } = usePricing({
-    couponCode: ppcCoupon,
-    couponCodeForLifetime: ppcCoupon,
-  });
+  } = usePricing(ppcCoupon);
 
   const onCheckoutButtonClicked = async (
     priceId: string,
@@ -71,7 +70,13 @@ const MegaComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, foot
       <Script type="application/ld+json" strategy="beforeInteractive">
         {sm_breadcrumb('Mega alternative', 'mega-alternative')}
       </Script>
-      <Layout title={metatags[0].title} description={metatags[0].description} segmentName="mega Comparison" lang={lang}>
+      <Layout
+        title={metatags[0].title}
+        description={metatags[0].description}
+        segmentName="PPC Mega Comparison"
+        lang={lang}
+        robots="noindex, follow"
+      >
         <Navbar textContent={navbarLang} lang={lang} cta={['priceTable']} fixed />
         <HeroSection textContent={langJson.HeroSection} percentage={percentageDiscount} competitor={'Mega'} />
 

--- a/src/pages/ppc/pcloud-alternative.tsx
+++ b/src/pages/ppc/pcloud-alternative.tsx
@@ -15,12 +15,14 @@ import { HeroSection } from '@/components/comparison/HeroSection';
 import Footer from '@/components/layout/footers/Footer';
 import { sm_breadcrumb } from '@/components/utils/schema-markup-generator';
 import Script from 'next/script';
-import { useRouter } from 'next/router';
+import usePpcCoupon from '@/hooks/usePpcCoupon';
 
 const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, footerLang }): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'pcloud-alternative');
-  const router = useRouter();
-  const ppcCoupon = router.query.utm_source === 'google' ? PromoCodeName.GADS85 : PromoCodeName.META85;
+  const ppcCoupon = usePpcCoupon({
+    couponCode: PromoCodeName.PCLOUD85,
+    couponCodeForLifetime: PromoCodeName.PCLOUD85,
+  });
 
   const {
     products,
@@ -29,10 +31,7 @@ const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
     coupon: individualCoupon,
     lifetimeCoupon: lifetimeCoupon,
     lifetimeCoupons,
-  } = usePricing({
-    couponCode: ppcCoupon,
-    couponCodeForLifetime: ppcCoupon,
-  });
+  } = usePricing(ppcCoupon);
 
   const onCheckoutButtonClicked = async (
     priceId: string,
@@ -73,7 +72,8 @@ const PCloudComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
       <Layout
         title={metatags[0].title}
         description={metatags[0].description}
-        segmentName="pCloud Comparison"
+        segmentName="PPC pCloud Comparison"
+        robots="noindex, follow"
         lang={lang}
       >
         <Navbar textContent={navbarLang} lang={lang} cta={['priceTable']} fixed />

--- a/src/pages/ppc/pricing.tsx
+++ b/src/pages/ppc/pricing.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import Script from 'next/script';
-import { useRouter } from 'next/router';
+import usePpcCoupon from '@/hooks/usePpcCoupon';
 import { GetServerSidePropsContext } from 'next';
 import Footer from '@/components/layout/footers/Footer';
 import Navbar from '@/components/layout/navbars/Navbar';
@@ -41,8 +41,10 @@ const Pricing = ({
   relationalLinksText,
 }: PricingProps): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'pricing');
-  const router = useRouter();
-  const ppcCoupon = router.query.utm_source === 'google' ? PromoCodeName.GADS85 : PromoCodeName.META85;
+  const ppcCoupon = usePpcCoupon({
+    couponCode: PromoCodeName.OFFSUB,
+    couponCodeForLifetime: PromoCodeName.OFFLFT,
+  });
 
   const {
     products,
@@ -51,10 +53,7 @@ const Pricing = ({
     coupon: individualCoupon,
     lifetimeCoupon: lifetimeCoupon,
     lifetimeCoupons,
-  } = usePricing({
-    couponCode: ppcCoupon,
-    couponCodeForLifetime: ppcCoupon,
-  });
+  } = usePricing(ppcCoupon);
 
   const [pageName, setPageName] = useState('Pricing Individuals Annually');
   const [isBusiness, setIsBusiness] = useState<boolean>(false);
@@ -120,7 +119,13 @@ const Pricing = ({
         {sm_breadcrumb('Cloud Storage Pricing', 'pricing')}
       </Script>
 
-      <Layout segmentName={pageName} title={metatags[0].title} description={metatags[0].description} lang={lang}>
+      <Layout
+        segmentName={`PPC ${pageName}`}
+        title={metatags[0].title}
+        description={metatags[0].description}
+        lang={lang}
+        robots="noindex, follow"
+      >
         <Navbar textContent={navbarLang} lang={lang} cta={['default']} fixed />
 
         <PricingSectionWrapper

--- a/src/pages/ppc/private-cloud-storage-solutions.tsx
+++ b/src/pages/ppc/private-cloud-storage-solutions.tsx
@@ -18,7 +18,6 @@ import AnimatedHeroSection from '@/components/shared/HeroSections/AnimatedHeroSe
 import Link from 'next/link';
 import { ShieldCheck } from '@phosphor-icons/react';
 
-
 interface PrivacyProps {
   metatagsDescriptions: MetatagsDescription[];
   textContent: PrivateCloudStorageSolutionsText;
@@ -89,12 +88,17 @@ const PrivateCloudStorageSolutions = ({
       </Script>
 
       <Script type="application/ld+json" strategy="beforeInteractive">
-        {sm_breadcrumb_list([{ name: 'Encrypted Cloud Storage', url: '/' }, { name: 'Secure cloud storage', url: '/drive' }, { name: 'Private cloud storage', url: '/private-cloud-storage-solutions' }])}
+        {sm_breadcrumb_list([
+          { name: 'Encrypted Cloud Storage', url: '/' },
+          { name: 'Secure cloud storage', url: '/drive' },
+          { name: 'Private cloud storage', url: '/private-cloud-storage-solutions' },
+        ])}
       </Script>
       <Layout
         title={metatags[0].title}
         description={metatags[0].description}
-        segmentName="Private Cloud Storage Solutions"
+        segmentName="PPC Private Cloud Storage Solutions"
+        robots="noindex, follow"
         lang={lang}
       >
         <Navbar textContent={navbarLang} lang={lang} cta={['default']} fixed />
@@ -165,7 +169,15 @@ const PrivateCloudStorageSolutions = ({
 
         <RelationalLinks textContent={relationalLinksText} />
 
-        <Footer textContent={footerLang} lang={lang} breadcrumbItems={[{ name: 'Encrypted Cloud Storage', url: '/' }, { name: 'Secure cloud storage', url: '/drive' }, { name: 'Private cloud storage', url: '/private-cloud-storage-solutions' }]} />
+        <Footer
+          textContent={footerLang}
+          lang={lang}
+          breadcrumbItems={[
+            { name: 'Encrypted Cloud Storage', url: '/' },
+            { name: 'Secure cloud storage', url: '/drive' },
+            { name: 'Private cloud storage', url: '/private-cloud-storage-solutions' },
+          ]}
+        />
       </Layout>
     </>
   );

--- a/src/pages/ppc/proton-alternative.tsx
+++ b/src/pages/ppc/proton-alternative.tsx
@@ -18,13 +18,15 @@ import ThreeCardsSection from '@/components/shared/sections/ThreeCardsSection';
 import { formatText } from '@/components/utils/format-text';
 import { sm_breadcrumb } from '@/components/utils/schema-markup-generator';
 import Script from 'next/script';
-import { useRouter } from 'next/router';
+import usePpcCoupon from '@/hooks/usePpcCoupon';
 
 const ProtonComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, footerLang }): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'proton-drive-alternative');
 
-  const router = useRouter();
-  const ppcCoupon = router.query.utm_source === 'google' ? PromoCodeName.GADS85 : PromoCodeName.META85;
+  const ppcCoupon = usePpcCoupon({
+    couponCode: PromoCodeName.PROTONDRIVE,
+    couponCodeForLifetime: PromoCodeName.PROTONDRIVE,
+  });
 
   const {
     products,
@@ -33,10 +35,7 @@ const ProtonComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
     coupon: individualCoupon,
     lifetimeCoupon: lifetimeCoupon,
     lifetimeCoupons,
-  } = usePricing({
-    couponCode: ppcCoupon,
-    couponCodeForLifetime: ppcCoupon,
-  });
+  } = usePricing(ppcCoupon);
 
   const onCheckoutButtonClicked = async (
     priceId: string,
@@ -80,7 +79,8 @@ const ProtonComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, fo
       <Layout
         title={metatags[0].title}
         description={metatags[0].description}
-        segmentName={'Drive Comparison'}
+        segmentName="PPC Proton Comparison"
+        robots="noindex, follow"
         lang={lang}
       >
         <Navbar textContent={navbarLang} lang={locale} cta={['priceTable']} fixed />

--- a/src/pages/ppc/terabox-alternative.tsx
+++ b/src/pages/ppc/terabox-alternative.tsx
@@ -18,12 +18,14 @@ import ThreeCardsSection from '@/components/shared/sections/ThreeCardsSection';
 import { formatText } from '@/components/utils/format-text';
 import { sm_breadcrumb } from '@/components/utils/schema-markup-generator';
 import Script from 'next/script';
-import { useRouter } from 'next/router';
+import usePpcCoupon from '@/hooks/usePpcCoupon';
 
 const TeraboxComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, footerLang }): JSX.Element => {
   const metatags = metatagsDescriptions.filter((desc) => desc.id === 'terabox-alternative');
-  const router = useRouter();
-  const ppcCoupon = router.query.utm_source === 'google' ? PromoCodeName.GADS85 : PromoCodeName.META85;
+  const ppcCoupon = usePpcCoupon({
+    couponCode: PromoCodeName.TERABOX85,
+    couponCodeForLifetime: PromoCodeName.TERABOX85,
+  });
 
   const {
     products,
@@ -32,10 +34,7 @@ const TeraboxComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, f
     coupon: individualCoupon,
     lifetimeCoupon: lifetimeCoupon,
     lifetimeCoupons,
-  } = usePricing({
-    couponCode: ppcCoupon,
-    couponCodeForLifetime: ppcCoupon,
-  });
+  } = usePricing(ppcCoupon);
 
   const onCheckoutButtonClicked = async (
     priceId: string,
@@ -79,7 +78,8 @@ const TeraboxComparison = ({ metatagsDescriptions, langJson, lang, navbarLang, f
       <Layout
         title={metatags[0].title}
         description={metatags[0].description}
-        segmentName={'Drive Comparison'}
+        segmentName="PPC Terabox Comparison"
+        robots="noindex, follow"
         lang={lang}
       >
         <Navbar textContent={navbarLang} lang={locale} cta={['priceTable']} fixed />


### PR DESCRIPTION
Add `usePpcCoupon`:/ppc landings apply META85 if they detect `fbclid` and GADS85 if they detect `gclid`/`utm_source=google`; in any other case they fall to the coupon of their equivalent landing (OFFSUB/OFFLFT at home, boost and prices; MEGA85, PCLOUD85, PROTONDRIVE85 and TERABOX85 in the comparisons), in view of the default META85 that is served so far to direct and organic traffic.
Mark the 8 pages of /ppc as `noindex, follow` and add `Disallow: /ppc` to robots.txt, so that they do not compete on the stock market with their normal equivalents or index discounted campaign prices.
Prefix the `segmentName` with `PPC` and separate the duplicate that proton-alternative and terabox-alternative shared (`Drive Comparison`), so that paid traffic stops mixing with organic traffic in Segment and each LP is attributable separately.
