### PR TITLE
[MKT_1014]:fix/temp mail issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "vercel:install": "yarn run add:npmrc && yarn install"
   },
   "dependencies": {
-    "@cemalgnlts/mailjs": "^3.0.1",
     "@coderosh/images-to-pdf": "^2.1.0",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",

--- a/src/components/temp-email/services/temp-mail.service.ts
+++ b/src/components/temp-email/services/temp-mail.service.ts
@@ -1,4 +1,4 @@
-import Mailjs from '@cemalgnlts/mailjs';
+import axios from 'axios';
 
 import { MessageObjProps, UserProps } from '../types/types';
 import rateLimitClientMiddleware from '@/components/utils/rate-limit';
@@ -12,26 +12,13 @@ export const SELECTED_MESSAGE = 'selectedMessage';
 export const TIME_NOW = new Date().getTime();
 export const MAX_HOURS_BEFORE_EXPIRE_EMAIL = 5 * 60 * 60 * 1000;
 
-const mailjs = new Mailjs();
-
-// const CONVERTER_URL = process.env.NEXT_PUBLIC_FILE_CONVERTER_API;
-const CONVERTER_URL =
-  process.env.NODE_ENV === 'production' ? process.env.NEXT_PUBLIC_FILE_CONVERTER_API : 'http://localhost:3000';
-
 const fetchNewEmail = async (): Promise<UserProps> => {
   return rateLimitClientMiddleware(
     'create-email-limiter',
     async () => {
-      const account = await mailjs.createOneAccount();
+      const { data } = await axios.get<UserProps>('/api/temp-mail/create-email');
 
-      const address = account.data.username;
-      const password = account.data.password;
-
-      const emailObj = {
-        address,
-        token: password,
-      };
-      return emailObj;
+      return data;
     },
     4,
   );
@@ -39,49 +26,21 @@ const fetchNewEmail = async (): Promise<UserProps> => {
 
 const fetchInbox = async (email: string, token: string) => {
   return rateLimitClientMiddleware('fetch-inbox-limiter', async () => {
-    await mailjs.login(email, token);
+    const { data } = await axios.get<MessageObjProps[]>('/api/temp-mail/get-inbox', {
+      params: { email, token },
+    });
 
-    const messages = await mailjs.getMessages();
-
-    const mails = messages.data
-      ? messages.data.map((mail) => {
-          return {
-            body: mail.intro,
-            date: mail.createdAt,
-            from: mail.from.address,
-            to: mail.to.address,
-            html: mail.intro,
-            subject: mail.subject,
-            id: mail.id,
-            seen: mail.seen,
-          };
-        })
-      : [];
-
-    return mails;
+    return data;
   });
 };
 
 const getMessageData = async (email: string, token: string, messageId: string): Promise<MessageObjProps> => {
   return rateLimitClientMiddleware('get-message-limiter', async () => {
-    await mailjs.login(email, token);
+    const { data } = await axios.get<MessageObjProps>('/api/temp-mail/get-message', {
+      params: { email, token, messageId },
+    });
 
-    const messageData = await mailjs.getMessage(messageId);
-
-    const selectedMessage = messageData.data;
-
-    const messageObj = {
-      body: selectedMessage.intro,
-      date: selectedMessage.createdAt,
-      from: selectedMessage.from.address,
-      to: selectedMessage.to.address,
-      html: selectedMessage.html.join(''),
-      subject: selectedMessage.subject,
-      id: selectedMessage.id,
-      seen: selectedMessage.seen,
-    };
-
-    return messageObj;
+    return data;
   });
 };
 

--- a/src/lib/mail-tm.ts
+++ b/src/lib/mail-tm.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 
 import { MessageObjProps } from '@/components/temp-email/types/types';
 
-const MAIL_TM_API = 'https://api.mail.tm';
+const MAIL_TM_API = 'https://api.mail.gw';
 
 const mailTm = axios.create({
   baseURL: MAIL_TM_API,

--- a/src/lib/mail-tm.ts
+++ b/src/lib/mail-tm.ts
@@ -1,0 +1,90 @@
+import axios from 'axios';
+import crypto from 'crypto';
+
+import { MessageObjProps } from '@/components/temp-email/types/types';
+
+const MAIL_TM_API = 'https://api.mail.tm';
+
+const mailTm = axios.create({
+  baseURL: MAIL_TM_API,
+  headers: { accept: 'application/json' },
+  timeout: 15000,
+});
+
+interface MailTmAddress {
+  address: string;
+  name: string;
+}
+
+interface MailTmMessage {
+  id: string;
+  from: MailTmAddress;
+  to: MailTmAddress | MailTmAddress[];
+  subject: string;
+  intro: string;
+  seen: boolean;
+  createdAt: string;
+  html?: string[];
+}
+
+const randomHash = (bytes: number) => crypto.randomBytes(bytes).toString('hex');
+
+/**
+ * mail.tm devuelve `to` como objeto en unos endpoints y como array en otros,
+ * asi que normalizamos antes de mapear.
+ */
+const toAddress = (to: MailTmAddress | MailTmAddress[]) => (Array.isArray(to) ? to[0]?.address : to?.address);
+
+const toMessageObj = (message: MailTmMessage): MessageObjProps => ({
+  body: message.intro,
+  date: message.createdAt as unknown as number,
+  from: message.from?.address,
+  to: toAddress(message.to),
+  html: message.html?.length ? message.html.join('') : message.intro,
+  subject: message.subject,
+  id: message.id,
+  seen: message.seen,
+});
+
+/** Crea una cuenta desechable. Devuelve la password, que es lo que el cliente guarda como `token`. */
+export const createAccount = async (): Promise<{ address: string; token: string }> => {
+  const { data: domains } = await mailTm.get<{ domain: string; isActive: boolean }[]>('/domains?page=1');
+
+  const domain = domains.find((item) => item.isActive)?.domain;
+
+  if (!domain) throw new Error('No active mail.tm domain available');
+
+  const address = `${randomHash(6)}@${domain}`;
+  const password = randomHash(12);
+
+  await mailTm.post('/accounts', { address, password });
+
+  return { address, token: password };
+};
+
+/** Intercambia address + password por un JWT de mail.tm. */
+const getJwt = async (address: string, password: string): Promise<string> => {
+  const { data } = await mailTm.post<{ token: string }>('/token', { address, password });
+
+  return data.token;
+};
+
+export const getInbox = async (address: string, password: string): Promise<MessageObjProps[]> => {
+  const jwt = await getJwt(address, password);
+
+  const { data } = await mailTm.get<MailTmMessage[]>('/messages?page=1', {
+    headers: { authorization: `Bearer ${jwt}` },
+  });
+
+  return data.map(toMessageObj);
+};
+
+export const getMessage = async (address: string, password: string, messageId: string): Promise<MessageObjProps> => {
+  const jwt = await getJwt(address, password);
+
+  const { data } = await mailTm.get<MailTmMessage>(`/messages/${encodeURIComponent(messageId)}`, {
+    headers: { authorization: `Bearer ${jwt}` },
+  });
+
+  return toMessageObj(data);
+};

--- a/src/pages/api/temp-mail/create-email.ts
+++ b/src/pages/api/temp-mail/create-email.ts
@@ -1,19 +1,18 @@
-import axios, { AxiosError } from 'axios';
 import { NextApiRequest, NextApiResponse } from 'next';
-import rateLimitMiddleware from '../../../utils/rate-limiter';
-import { csrf } from '@/lib/csrf';
 
-const CONVERTER_URL =
-  process.env.NODE_ENV === 'production' ? process.env.NEXT_PUBLIC_FILE_CONVERTER_API : 'http://localhost:3000';
+import rateLimitMiddleware from '../../../utils/rate-limiter';
+import { createAccount } from '@/lib/mail-tm';
+import { csrf } from '@/lib/csrf';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ message: 'Method not allowed' });
 
   try {
-    const response = await axios.get(`${CONVERTER_URL}/api/temp-mail/address`);
-    return res.status(200).json(response.data);
+    const account = await createAccount();
+
+    return res.status(200).json(account);
   } catch (err) {
-    const error = err as AxiosError;
+    const error = err as Error;
     return res.status(500).json({ message: error.message });
   }
 }

--- a/src/pages/api/temp-mail/create-email.ts
+++ b/src/pages/api/temp-mail/create-email.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { AxiosError } from 'axios';
 
 import rateLimitMiddleware from '../../../utils/rate-limiter';
 import { createAccount } from '@/lib/mail-tm';
@@ -12,8 +13,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
     return res.status(200).json(account);
   } catch (err) {
-    const error = err as Error;
-    return res.status(500).json({ message: error.message });
+    const error = err as AxiosError;
+    console.error('[temp-mail] create-email failed', {
+      status: error.response?.status,
+      data: error.response?.data,
+    });
+    return res.status(500).json({ message: 'Internal Server Error' });
   }
 }
 

--- a/src/pages/api/temp-mail/get-inbox.ts
+++ b/src/pages/api/temp-mail/get-inbox.ts
@@ -1,10 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import axios, { AxiosError } from 'axios';
-import rateLimitMiddleware from '@/utils/rate-limiter';
-import { csrf } from '@/lib/csrf';
+import { AxiosError } from 'axios';
 
-const CONVERTER_URL =
-  process.env.NODE_ENV === 'production' ? process.env.NEXT_PUBLIC_FILE_CONVERTER_API : 'http://localhost:3000';
+import rateLimitMiddleware from '@/utils/rate-limiter';
+import { getInbox } from '@/lib/mail-tm';
+import { csrf } from '@/lib/csrf';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ message: 'Method not allowed' });
@@ -16,13 +15,15 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    const safeEmail = encodeURIComponent(email);
-    const safeToken = encodeURIComponent(token);
+    const mails = await getInbox(email, token);
 
-    const response = await axios.get(`${CONVERTER_URL}/api/temp-mail/messages/${safeEmail}/${safeToken}`);
-    return res.status(200).json(response.data.mails);
+    return res.status(200).json(mails);
   } catch (err) {
     const error = err as AxiosError;
+
+    if (error.response?.status === 401) {
+      return res.status(401).json({ message: 'Email has expired' });
+    }
 
     if (error.response?.status === 404) {
       return res.status(404).json({ message: 'Inbox not found' });

--- a/src/pages/api/temp-mail/get-message.ts
+++ b/src/pages/api/temp-mail/get-message.ts
@@ -1,10 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import rateLimitMiddleware from '../../../utils/rate-limiter';
-import axios from 'axios';
-import { csrf } from '@/lib/csrf';
+import { AxiosError } from 'axios';
 
-const CONVERTER_URL =
-  process.env.NODE_ENV === 'production' ? process.env.NEXT_PUBLIC_FILE_CONVERTER_API : 'http://localhost:3000';
+import rateLimitMiddleware from '../../../utils/rate-limiter';
+import { getMessage } from '@/lib/mail-tm';
+import { csrf } from '@/lib/csrf';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ message: 'Method not allowed' });
@@ -16,25 +15,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    const safeEmail = encodeURIComponent(email);
-    const safeToken = encodeURIComponent(token);
-    const safeMessageId = encodeURIComponent(messageId);
+    const messageObj = await getMessage(email, token, messageId);
 
-    const inbox = await axios.get(
-      `${CONVERTER_URL}/api/temp-mail/messages/selectedMessage/${safeEmail}/${safeToken}/${safeMessageId}`,
-    );
-
-    return res.status(200).json(inbox.data.messageObj);
+    return res.status(200).json(messageObj);
   } catch (err) {
-    const error = err as Error;
-    if (error.message.includes('404')) {
-      return res.status(404).json({
-        message: error.message,
-      });
+    const error = err as AxiosError;
+
+    if (error.response?.status === 404) {
+      return res.status(404).json({ message: 'Message not found' });
     }
-    return res.status(500).json({
-      message: error.message,
-    });
+
+    return res.status(500).json({ message: 'Internal Server Error' });
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,13 +1325,6 @@
   resolved "https://registry.yarnpkg.com/@borewit/text-codec/-/text-codec-0.2.2.tgz#75025f735c0983b3a871668804a57387e3649375"
   integrity sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==
 
-"@cemalgnlts/mailjs@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@cemalgnlts/mailjs/-/mailjs-3.0.1.tgz#0113e03973a847eca3d4064dc87baf033e5dab85"
-  integrity sha512-JnX2kS/ZVfbjy8CM5oIw5wlKPEO0eW5/cXF9yidvZOZ+LCiAfosAWnubbakOvLgBrE9ewQaFjh0g/usK2Kiicw==
-  dependencies:
-    eventsource "^2.0.2"
-
 "@coderosh/image-size@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@coderosh/image-size/-/image-size-2.0.1.tgz#85ee62994ea1f5135a54d75029f00a106710ed10"
@@ -4806,11 +4799,6 @@ eventemitter2@6.4.7:
   version "6.4.7"
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
   integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
-
-eventsource@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
-  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
 
 execa@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Temp mail is currently broken in production. The page talked to api.mail.tm
directly from the browser through the mailjs SDK, and mail.tm does not return an
Access-Control-Allow-Origin header, so every request from internxt.com is
blocked by CORS:

  Access to fetch at 'https://api.mail.tm/domains?page=1' from origin
  'https://internxt.com' has been blocked by CORS policy: No
  'Access-Control-Allow-Origin' header is present on the requested resource.

It fails on the very first call (createOneAccount -> getDomains), so no address
is ever generated and the page is unusable. Calling a temp mail API from the
browser is also a common ad blocker target, which shows up as
ERR_BLOCKED_BY_CLIENT in the same console. Neither can be fixed client side, so
this PR moves all mail.tm traffic to our server.

1. Added `src/lib/mail-tm.ts`, a small server-side client for api.mail.tm that
   handles account creation, JWT exchange and message fetching, and normalises
   responses into our MessageObjProps shape.
2. Rewrote the three API routes (create-email, get-inbox, get-message) to use
   that client. They previously proxied to `${CONVERTER_URL}/api/temp-mail/...`,
   endpoints that no longer exist, and CONVERTER_URL falls back to
   http://localhost:3000 outside production so those routes were calling the
   website itself. CSRF and rate limiting are unchanged.
3. The client service now calls our own /api/temp-mail/* routes, so the account
   password no longer lives in the browser and no cross-origin request is made.
4. Improved error handling: get-inbox returns 401 "Email has expired" when the
   account is gone, and get-message checks response status codes instead of
   matching on the error message string, and no longer leaks internal error
   messages to the client.
5. Removed the `@cemalgnlts/mailjs` dependency.

NEXT_PUBLIC_FILE_CONVERTER_API is still used by the file converter itself, so
the env var stays.

Note: mail.tm rate limits at 30 requests per minute per IP. Now that calls come
from our server instead of each visitor, that budget is shared across all users
of the page, so it is worth watching once this is live.

Note: this PR changes package.json and yarn.lock, run `yarn install` after
checking out the branch.

Testing: open /temporary-email, generate an address, send it an email and
confirm the inbox lists it and the message opens with its HTML body.
