### PR TITLE
[MKT-1021]feat/duplicate antivirus LP

### DIFF
--- a/src/assets/lang/de/antivirus.json
+++ b/src/assets/lang/de/antivirus.json
@@ -12,7 +12,8 @@
       "downloadForLinux": "Linux herunterladen"
     },
     "cta": "Internxt kaufen",
-    "price": "Ab {currency}{price}/Monat"
+    "price": "Ab {currency}{price}/Monat",
+    "priceAnnual": "Ab {currency}{price}/Jahr"
   },
   "cta1": {
     "title": "Internxt Antivirus",

--- a/src/assets/lang/de/navbar.json
+++ b/src/assets/lang/de/navbar.json
@@ -103,6 +103,7 @@
   "MinimalNavbar": {
     "secondaryEyeBrow": "Antivirus",
     "cta": "Internxt erhalten",
-    "price": "Ab {currency}{price}/Monat"
+    "price": "Ab {currency}{price}/Monat",
+    "priceAnnual": "Ab {currency}{price}/Jahr"
   }
 }

--- a/src/assets/lang/en/antivirus.json
+++ b/src/assets/lang/en/antivirus.json
@@ -12,7 +12,8 @@
       "downloadForLinux": "Download for Linux"
     },
     "cta": "Get Internxt",
-    "price": "From {currency}{price}/mo"
+    "price": "From {currency}{price}/month",
+    "priceAnnual": "From {currency}{price}/year"
   },
   "cta1": {
     "title": "Internxt Antivirus",

--- a/src/assets/lang/en/navbar.json
+++ b/src/assets/lang/en/navbar.json
@@ -103,6 +103,7 @@
   "MinimalNavbar": {
     "secondaryEyeBrow": "Antivirus",
     "cta": "Get Internxt",
-    "price": "From {currency}{price}/mo"
+    "price": "From {currency}{price}/month",
+    "priceAnnual": "From {currency}{price}/year"
   }
 }

--- a/src/assets/lang/es/antivirus.json
+++ b/src/assets/lang/es/antivirus.json
@@ -12,7 +12,8 @@
       "downloadForLinux": "Descarga Linux"
     },
     "cta": "Obtener Internxt",
-    "price": "Desde {currency}{price}/mes"
+    "price": "Desde {currency}{price}/mes",
+    "priceAnnual": "Desde {currency}{price}/año"
   },
   "cta1": {
     "title": "Internxt Antivirus",

--- a/src/assets/lang/es/navbar.json
+++ b/src/assets/lang/es/navbar.json
@@ -102,6 +102,7 @@
   "MinimalNavbar": {
     "secondaryEyeBrow": "Antivirus",
     "cta": "Obtener Internxt",
-    "price": "Desde {currency}{price}/mes"
+    "price": "Desde {currency}{price}/mes",
+    "priceAnnual": "Desde {currency}{price}/año"
   }
 }

--- a/src/assets/lang/fr/antivirus.json
+++ b/src/assets/lang/fr/antivirus.json
@@ -12,7 +12,8 @@
       "downloadForLinux": "Télécharger pour Linux"
     },
     "cta": "Obtenir Internxt",
-    "price": "À partir de {currency}{price}/mois"
+    "price": "À partir de {currency}{price}/mois",
+    "priceAnnual": "À partir de {currency}{price}/an"
   },
   "cta1": {
     "title": "Internxt Antivirus",

--- a/src/assets/lang/fr/navbar.json
+++ b/src/assets/lang/fr/navbar.json
@@ -102,6 +102,7 @@
   "MinimalNavbar": {
     "secondaryEyeBrow": "Antivirus",
     "cta": "Obtenir Internxt",
-    "price": "À partir de {currency}{price}/mois"
+    "price": "À partir de {currency}{price}/mois",
+    "priceAnnual": "À partir de {currency}{price}/an"
   }
 }

--- a/src/assets/lang/it/antivirus.json
+++ b/src/assets/lang/it/antivirus.json
@@ -12,7 +12,8 @@
       "downloadForLinux": "Scarica per Linux"
     },
     "cta": "Ottieni Internxt",
-    "price": "Da {currency}{price}/mese"
+    "price": "Da {currency}{price}/mese",
+    "priceAnnual": "Da {currency}{price}/anno"
   },
   "cta1": {
     "title": "Internxt Antivirus",

--- a/src/assets/lang/it/navbar.json
+++ b/src/assets/lang/it/navbar.json
@@ -103,6 +103,7 @@
   "MinimalNavbar": {
     "secondaryEyeBrow": "Antivirus",
     "cta": "Ottieni Internxt",
-    "price": "Da {currency}{price}/mese"
+    "price": "Da {currency}{price}/mese",
+    "priceAnnual": "Da {currency}{price}/anno"
   }
 }

--- a/src/assets/lang/pt-br/antivirus.json
+++ b/src/assets/lang/pt-br/antivirus.json
@@ -12,7 +12,8 @@
       "downloadForLinux": "Baixar para Linux"
     },
     "cta": "Obter Internxt",
-    "price": "A partir de {currency}{price}/mês"
+    "price": "A partir de {currency}{price}/mês",
+    "priceAnnual": "A partir de {currency}{price}/ano"
   },
   "cta1": {
     "title": "Internxt Antivirus",

--- a/src/assets/lang/pt-br/navbar.json
+++ b/src/assets/lang/pt-br/navbar.json
@@ -95,6 +95,7 @@
   "MinimalNavbar": {
     "secondaryEyeBrow": "Antivirus",
     "cta": "Obtenha o Internxt",
-    "price": "A partir de {currency}29,99/mês"
+    "price": "A partir de {currency}29,99/mês",
+    "priceAnnual": "A partir de {currency}{price}/ano"
   }
 }

--- a/src/assets/lang/ru/antivirus.json
+++ b/src/assets/lang/ru/antivirus.json
@@ -12,7 +12,8 @@
       "downloadForLinux": "Скачать для Linux"
     },
     "cta": "Получить Internxt",
-    "price": "От {currency}{price}/мес"
+    "price": "От {currency}{price}/мес",
+    "priceAnnual": "От {currency}{price}/год"
   },
   "cta1": {
     "title": "Internxt Antivirus",

--- a/src/assets/lang/ru/navbar.json
+++ b/src/assets/lang/ru/navbar.json
@@ -103,6 +103,7 @@
   "MinimalNavbar": {
     "secondaryEyeBrow": "Антивирус",
     "cta": "Получить Internxt",
-    "price": "От {currency}{price}/мес"
+    "price": "От {currency}{price}/мес",
+    "priceAnnual": "От {currency}{price}/год"
   }
 }

--- a/src/assets/lang/zh-tw/antivirus.json
+++ b/src/assets/lang/zh-tw/antivirus.json
@@ -12,7 +12,8 @@
       "downloadForLinux": "下载适用于 Linux"
     },
     "cta": "取得 Internxt",
-    "price": "每月 {currency}{price} 起"
+    "price": "每月 {currency}{price} 起",
+    "priceAnnual": "每年 {currency}{price} 起"
   },
   "cta1": {
     "title": "Internxt Antivirus",

--- a/src/assets/lang/zh-tw/navbar.json
+++ b/src/assets/lang/zh-tw/navbar.json
@@ -104,6 +104,7 @@
   "MinimalNavbar": {
     "secondaryEyeBrow": "防毒軟體",
     "cta": "取得 Internxt",
-    "price": "從 {currency}{price}/月"
+    "price": "從 {currency}{price}/月",
+    "priceAnnual": "從 {currency}{price}/年"
   }
 }

--- a/src/assets/lang/zh/antivirus.json
+++ b/src/assets/lang/zh/antivirus.json
@@ -12,7 +12,8 @@
       "downloadForLinux": "下载适用于 Linux"
     },
     "cta": "获取 Internxt",
-    "price": "从 {currency}{price}/月起"
+    "price": "从 {currency}{price}/月起",
+    "priceAnnual": "从 {currency}{price}/年起"
   },
   "cta1": {
     "title": "Internxt Antivirus",

--- a/src/assets/lang/zh/navbar.json
+++ b/src/assets/lang/zh/navbar.json
@@ -103,6 +103,7 @@
   "MinimalNavbar": {
     "secondaryEyeBrow": "杀毒软件",
     "cta": "获取 Internxt",
-    "price": "从 {currency}{price}/月"
+    "price": "从 {currency}{price}/月",
+    "priceAnnual": "从 {currency}{price}/年"
   }
 }

--- a/src/assets/types/layout/types.ts
+++ b/src/assets/types/layout/types.ts
@@ -16,6 +16,7 @@ export interface NavigationBarText {
     secondaryEyeBrow: string;
     cta: string;
     price: string;
+    priceAnnual: string;
   };
 }
 

--- a/src/components/antivirus/AlternativeHeroSection.tsx
+++ b/src/components/antivirus/AlternativeHeroSection.tsx
@@ -6,9 +6,10 @@ interface AlternativeHeroSectionProps {
   textContent: any;
   currentPrice?: string;
   currency?: string;
+  isAnnual?: boolean;
 }
 
-const AlternativeHeroSection = ({ textContent, currentPrice, currency }: AlternativeHeroSectionProps) => (
+const AlternativeHeroSection = ({ textContent, currentPrice, currency, isAnnual }: AlternativeHeroSectionProps) => (
   <section
     className="mt-20 flex h-min w-full flex-col items-center overflow-hidden px-6 py-10 lg:mt-16 lg:h-[705px] lg:flex-row lg:justify-between lg:px-10 xl:px-32 3xl:px-80"
     style={{ background: 'linear-gradient(360deg, #FFFFFF 0%, #E5EFFF 85.17%)' }}
@@ -42,7 +43,9 @@ const AlternativeHeroSection = ({ textContent, currentPrice, currency }: Alterna
           </Link>
 
           <span className="h-min rounded-2 bg-green-100 px-1 py-0.5 text-sm font-semibold text-green-0">
-            {textContent.price?.replace('{currency}', currency || '').replace('{price}', currentPrice || '')}
+            {(isAnnual ? textContent.priceAnnual ?? textContent.price : textContent.price)
+              ?.replace('{currency}', currency || '')
+              .replace('{price}', currentPrice || '')}
           </span>
         </div>
       </div>

--- a/src/components/layout/navbars/MinimalNavbar.tsx
+++ b/src/components/layout/navbars/MinimalNavbar.tsx
@@ -10,9 +10,10 @@ export interface MinimalNavbarProps {
   isOffer?: boolean;
   textContent?: NavigationBarText;
   price?: string;
+  isAnnual?: boolean;
 }
 
-export const MinimalNavbar = ({ isOffer, textContent, price }: MinimalNavbarProps) => {
+export const MinimalNavbar = ({ isOffer, textContent, price, isAnnual }: MinimalNavbarProps) => {
   const [scrolled, setScrolled] = useState<boolean>(true);
   const [currencySymbol, setCurrencySymbol] = useState<string>('€');
 
@@ -29,9 +30,11 @@ export const MinimalNavbar = ({ isOffer, textContent, price }: MinimalNavbarProp
     });
   }, []);
 
-  const priceLabel = textContent?.MinimalNavbar.price
-    .replace('{currency}', currencySymbol)
-    .replace('{price}', price || '');
+  const priceTemplate = isAnnual
+    ? textContent?.MinimalNavbar.priceAnnual ?? textContent?.MinimalNavbar.price
+    : textContent?.MinimalNavbar.price;
+
+  const priceLabel = priceTemplate?.replace('{currency}', currencySymbol).replace('{price}', price || '');
 
   return (
     <div

--- a/src/components/shared/pricing/PriceCard/HorizontalPriceCard.tsx
+++ b/src/components/shared/pricing/PriceCard/HorizontalPriceCard.tsx
@@ -18,6 +18,7 @@ import {
 } from '@phosphor-icons/react';
 import { checkout } from '@/lib/auth';
 import { PromoCodeProps } from '@/lib/types';
+import { Interval } from '@/services/stripe.service';
 
 export interface HorizontalPriceCardProps {
   decimalDiscountValue?: number;
@@ -29,6 +30,7 @@ export interface HorizontalPriceCardProps {
   planId: string;
   currencyValue: string;
   coupon: PromoCodeProps | undefined;
+  interval?: Interval;
 }
 
 export const HorizontalPriceCard = ({
@@ -40,6 +42,7 @@ export const HorizontalPriceCard = ({
   planId,
   currencyValue,
   coupon,
+  interval = Interval.Month,
 }: HorizontalPriceCardProps): JSX.Element | null => {
   if (!storage) {
     return null;
@@ -57,6 +60,12 @@ export const HorizontalPriceCard = ({
       '5TB': contentText.productFeatures.planTypes.ultimate,
       '1TB': contentText.productFeatures.planTypes.essentials,
     }[storage] || null;
+  const intervalLabel =
+    {
+      [Interval.Month]: contentText.perMonth,
+      [Interval.Year]: contentText.perYear,
+      [Interval.Lifetime]: '',
+    }[interval] ?? contentText.perMonth;
 
   const iconsFeatures = [
     Database,
@@ -103,13 +112,13 @@ export const HorizontalPriceCard = ({
             <p className="flex flex-row items-end whitespace-nowrap font-medium text-gray-100">
               <span className="text-4xl font-bold">{currentPrice}</span>
               <span>{currency}</span>
-              <span className="text-sm">{contentText.perMonth}</span>
+              <span className="text-sm">{intervalLabel}</span>
             </p>
             {showDiscount && (
               <p className="flex flex-row items-end whitespace-nowrap font-normal text-gray-50">
                 <span className="text-xl line-through">{price}</span>
                 <span className="text-sm">{currency}</span>
-                <span className="text-sm">{contentText.perMonth}</span>
+                <span className="text-sm">{intervalLabel}</span>
               </p>
             )}
           </div>

--- a/src/components/shared/pricing/PriceCard/HorizontalPriceCard.tsx
+++ b/src/components/shared/pricing/PriceCard/HorizontalPriceCard.tsx
@@ -55,6 +55,7 @@ export const HorizontalPriceCard = ({
   const cardLabel =
     {
       '5TB': contentText.productFeatures.planTypes.ultimate,
+      '1TB': contentText.productFeatures.planTypes.essentials,
     }[storage] || null;
 
   const iconsFeatures = [

--- a/src/pages/ultimate/annual/antivirus.tsx
+++ b/src/pages/ultimate/annual/antivirus.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useState } from 'react';
 import { GetServerSidePropsContext } from 'next';
 import { FooterText, MetatagsDescription, NavigationBarText } from '@/assets/types/layout/types';
 import Layout from '@/components/layout/Layout';
@@ -19,11 +20,12 @@ import { downloadDriveLinks } from '@/lib/get-download-url';
 import { MinimalFooter } from '@/components/layout/footers/MinimalFooter';
 import { HorizontalPriceCard } from '@/components/shared/pricing/PriceCard/HorizontalPriceCard';
 import usePricing from '@/hooks/usePricing';
-import { Interval } from '@/services/stripe.service';
+import { PlanById, stripeService } from '@/services/stripe.service';
 import { analyticsService } from '@/services/ga.services';
 import { handleImpactEvent } from '@/services/impact.service';
 import { checkout } from '@/lib/auth';
 
+const ESSENTIAL_PLAN_PRICE_ID = 'price_1U6Ev3FAOdcgaBMQHxOAmWPO';
 const CLAIM_DEAL_CTA_SELECTOR = 'a[href$="#priceCard"], #choose-storage-button, #billingButtons button';
 const CLAIM_DEAL_EVENT = 'Claim Deal';
 
@@ -105,11 +107,26 @@ const AntivirusPage = ({
     },
   ];
 
-  const { products, currency, currencyValue, lifetimeCoupon } = usePricing({
+  const { currency, currencyValue, lifetimeCoupon, loadingCards } = usePricing({
     couponCodeForLifetime: PromoCodeName.antivirus,
   });
 
-  const essentialPlan = products?.individuals?.[Interval.Year]?.find((plan: any) => plan.storage === '1TB');
+  const [essentialPlan, setEssentialPlan] = useState<PlanById>();
+
+  useEffect(() => {
+    if (loadingCards) return;
+
+    let isStale = false;
+
+    stripeService.getPlanById(ESSENTIAL_PLAN_PRICE_ID, currencyValue).then((plan) => {
+      if (!isStale) setEssentialPlan(plan);
+    });
+
+    return () => {
+      isStale = true;
+    };
+  }, [loadingCards, currencyValue]);
+
   const decimalDiscountForLifetime = lifetimeCoupon?.percentOff && 100 - lifetimeCoupon.percentOff;
 
   const handleClaimDealClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -126,13 +143,11 @@ const AntivirusPage = ({
 
     handleImpactEvent({ event: CLAIM_DEAL_EVENT, properties: ctaProperties });
 
-    if (!essentialPlan) return;
-
     event.preventDefault();
     event.stopPropagation();
 
     checkout({
-      planId: essentialPlan.priceId,
+      planId: ESSENTIAL_PLAN_PRICE_ID,
       mode: 'payment',
       planType: 'individual',
       currency: currencyValue ?? 'eur',
@@ -143,12 +158,19 @@ const AntivirusPage = ({
   return (
     <div onClickCapture={handleClaimDealClick}>
       <Layout title={metatags[0].title} description={metatags[0].description} segmentName="Home" lang={lang}>
-        <MinimalNavbar lang={locale} isOffer textContent={navbarLang} price={essentialPlan?.price.toString()} />
+        <MinimalNavbar
+          lang={locale}
+          isOffer
+          isAnnual
+          textContent={navbarLang}
+          price={essentialPlan?.price.toString()}
+        />
 
         <AlternativeHeroSection
           textContent={langJson.HeroSection}
           currentPrice={essentialPlan?.price.toString()}
           currency={currency}
+          isAnnual
         />
 
         <InfoSection
@@ -176,6 +198,7 @@ const AntivirusPage = ({
               planId={essentialPlan.priceId}
               currencyValue={currencyValue}
               coupon={lifetimeCoupon}
+              interval={essentialPlan.interval}
             />
           </div>
         )}

--- a/src/pages/ultimate/annual/antivirus.tsx
+++ b/src/pages/ultimate/annual/antivirus.tsx
@@ -1,0 +1,263 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { GetServerSidePropsContext } from 'next';
+import { FooterText, MetatagsDescription, NavigationBarText } from '@/assets/types/layout/types';
+import Layout from '@/components/layout/Layout';
+import { MinimalNavbar } from '@/components/layout/navbars/MinimalNavbar';
+import { CardGroup } from '@/components/shared/CardGroup';
+import { ComponentsInColumnSection } from '@/components/shared/components/ComponentsInColumnSection';
+import CtaSection from '@/components/shared/CtaSection';
+import FAQSection from '@/components/shared/sections/FaqSection';
+import cookies from '@/lib/cookies';
+import { PromoCodeName } from '@/lib/types';
+import { BatteryCharging, Bomb, Broom, Browsers, Devices, ShieldCheck, ThermometerHot } from '@phosphor-icons/react';
+import { AntivirusText } from '@/assets/types/antivirus';
+import FeatureSectionV2 from '@/components/antivirus/FeatureSectionV2';
+import FeatureSection from '@/components/antivirus/FeatureSection';
+import AlternativeHeroSection from '@/components/antivirus/AlternativeHeroSection';
+import { InfoSection } from '@/components/antivirus/InfoSecction';
+import { downloadDriveLinks } from '@/lib/get-download-url';
+import { MinimalFooter } from '@/components/layout/footers/MinimalFooter';
+import { HorizontalPriceCard } from '@/components/shared/pricing/PriceCard/HorizontalPriceCard';
+import usePricing from '@/hooks/usePricing';
+import { Interval } from '@/services/stripe.service';
+import { analyticsService } from '@/services/ga.services';
+import { handleImpactEvent } from '@/services/impact.service';
+import { checkout } from '@/lib/auth';
+
+const CLAIM_DEAL_CTA_SELECTOR = 'a[href$="#priceCard"], #choose-storage-button, #billingButtons button';
+const CLAIM_DEAL_EVENT = 'Claim Deal';
+
+interface AntivirusProps {
+  lang: GetServerSidePropsContext['locale'];
+  metatagsDescriptions: MetatagsDescription[];
+  navbarLang: NavigationBarText;
+  langJson: AntivirusText;
+  footerLang: FooterText;
+  relationalLinksText: any;
+  download: {
+    Windows: any;
+    MacOS: any;
+    Linux: any;
+  };
+  isGetAntivirus?: boolean;
+}
+
+const AntivirusPage = ({
+  metatagsDescriptions,
+  langJson,
+  lang,
+  footerLang,
+  navbarLang,
+  isGetAntivirus,
+}: AntivirusProps): JSX.Element => {
+  const metatags = metatagsDescriptions.filter((desc) => desc.id === 'internxt-antivirus');
+  const locale = lang as string;
+
+  const cardsForComponentsIncolumn = [
+    {
+      icon: BatteryCharging,
+      title: langJson.ComponentsInColumn.cards.element1.title,
+      description: langJson.ComponentsInColumn.cards.element1.description,
+    },
+    {
+      icon: Bomb,
+      title: langJson.ComponentsInColumn.cards.element2.title,
+      description: langJson.ComponentsInColumn.cards.element2.description,
+    },
+    {
+      icon: Browsers,
+      title: langJson.ComponentsInColumn.cards.element3.title,
+      description: langJson.ComponentsInColumn.cards.element3.description,
+    },
+    {
+      icon: ThermometerHot,
+      title: langJson.ComponentsInColumn.cards.element4.title,
+      description: langJson.ComponentsInColumn.cards.element4.description,
+    },
+  ];
+  const infoSectionData = [
+    {
+      title: langJson.InfoSection.Percentage,
+      description: langJson.InfoSection.PercentageText,
+    },
+    {
+      title: langJson.InfoSection.MalwareRegisteredDaily,
+      description: langJson.InfoSection.MalwareRegisteredDailyText,
+    },
+    {
+      title: langJson.InfoSection.MalwareAttacks,
+      description: langJson.InfoSection.MalwareAttacksText,
+    },
+  ];
+
+  const InfoSectionV2 = [
+    {
+      icon: ShieldCheck,
+      title: langJson.InfoSectionV2.AntivirusProtection,
+    },
+    {
+      icon: Broom,
+      title: langJson.InfoSectionV2.RemoveMalware,
+    },
+    {
+      icon: Devices,
+      title: langJson.InfoSectionV2.DeviceProtection,
+    },
+  ];
+
+  const { products, currency, currencyValue, lifetimeCoupon } = usePricing({
+    couponCodeForLifetime: PromoCodeName.antivirus,
+  });
+
+  const essentialPlan = products?.individuals?.[Interval.Year]?.find((plan: any) => plan.storage === '1TB');
+  const decimalDiscountForLifetime = lifetimeCoupon?.percentOff && 100 - lifetimeCoupon.percentOff;
+
+  const handleClaimDealClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const cta = (event.target as HTMLElement).closest<HTMLElement>(CLAIM_DEAL_CTA_SELECTOR);
+    if (!cta) return;
+
+    const ctaProperties = {
+      page: 'ultimate-antivirus',
+      cta_id: cta.id || undefined,
+      cta_text: cta.textContent?.trim() || undefined,
+    };
+
+    analyticsService.trackCustomEvent(CLAIM_DEAL_EVENT, ctaProperties);
+
+    handleImpactEvent({ event: CLAIM_DEAL_EVENT, properties: ctaProperties });
+
+    if (!essentialPlan) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    checkout({
+      planId: essentialPlan.priceId,
+      mode: 'payment',
+      planType: 'individual',
+      currency: currencyValue ?? 'eur',
+      promoCodeId: lifetimeCoupon?.name,
+    });
+  };
+
+  return (
+    <div onClickCapture={handleClaimDealClick}>
+      <Layout title={metatags[0].title} description={metatags[0].description} segmentName="Home" lang={lang}>
+        <MinimalNavbar lang={locale} isOffer textContent={navbarLang} price={essentialPlan?.price.toString()} />
+
+        <AlternativeHeroSection
+          textContent={langJson.HeroSection}
+          currentPrice={essentialPlan?.price.toString()}
+          currency={currency}
+        />
+
+        <InfoSection
+          FirstComponent={
+            <div className="flex w-full flex-col items-center justify-center lg:flex-row lg:gap-32">
+              {infoSectionData.map((item, index) => (
+                <div key={index} className="flex flex-col items-center justify-center text-center">
+                  <p className="pb-5 text-4xl font-semibold text-primary">{item.title}</p>
+                  <p className="min-h-[80px] max-w-[229px] text-xl font-medium text-gray-80">{item.description}</p>
+                </div>
+              ))}
+            </div>
+          }
+        />
+
+        {essentialPlan && (
+          <div className="flex w-full justify-center px-6 py-12 lg:px-0 lg:py-24" id="priceCard">
+            <HorizontalPriceCard
+              decimalDiscountValue={decimalDiscountForLifetime || undefined}
+              storage={essentialPlan.storage}
+              popular={false}
+              currency={currency}
+              priceBefore={essentialPlan.price.toString().split('.')[0]}
+              price={Number(essentialPlan.price)}
+              planId={essentialPlan.priceId}
+              currencyValue={currencyValue}
+              coupon={lifetimeCoupon}
+            />
+          </div>
+        )}
+
+        <FeatureSection textContent={langJson.FeatureSection} isGetAntivirus={isGetAntivirus} showPlan />
+
+        <InfoSection
+          FirstComponent={
+            <div className="flex flex-col items-center justify-center space-y-5 md:flex-row md:space-x-20 md:space-y-0">
+              {InfoSectionV2.map((item, index) => (
+                <div key={index} className="flex flex-col items-center justify-center px-5 text-center">
+                  <item.icon className="text-primary" size={64} />
+                  <p className="pt-5 text-xl font-medium text-gray-80">{item.title}</p>
+                </div>
+              ))}
+            </div>
+          }
+        />
+
+        <CtaSection
+          textContent={langJson.cta1}
+          url={'#priceCard'}
+          customDescription={<p className="w-full text-xl font-normal">{langJson.cta1.subtitle}</p>}
+        />
+
+        <FeatureSectionV2 textContent={langJson.FeatureSectionV2} />
+
+        <ComponentsInColumnSection
+          FirstComponent={
+            <div className="flex w-full flex-col items-center gap-9 ">
+              <div className="flex max-w-[850px] flex-col items-center gap-6 text-center">
+                <h2 className="text-3xl font-semibold text-gray-100 lg:text-5xl">
+                  {langJson.ComponentsInColumn.title}
+                </h2>
+                <p className="font-regular text-xl text-gray-80">{langJson.ComponentsInColumn.description}</p>
+              </div>
+            </div>
+          }
+          SecondComponent={
+            <div className="flex flex-col items-center">
+              <CardGroup cards={cardsForComponentsIncolumn} backgroundColorCard="bg-white" />
+            </div>
+          }
+          backgroundColor="bg-white"
+        />
+        <CtaSection
+          textContent={langJson.cta2}
+          url={'#priceCard'}
+          customDescription={<p className="w-full  text-xl font-normal">{langJson.cta2.subtitle}</p>}
+        />
+
+        <FAQSection textContent={langJson.FaqSection} />
+
+        <MinimalFooter footerLang={footerLang.FooterSection} lang={locale} />
+      </Layout>
+    </div>
+  );
+};
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const download = await downloadDriveLinks();
+  const lang = ctx.locale;
+
+  const metatagsDescriptions = require(`@/assets/lang/${lang}/metatags-descriptions.json`);
+  const langJson = require(`@/assets/lang/${lang}/antivirus.json`);
+  const navbarLang = require(`@/assets/lang/${lang}/navbar.json`);
+  const footerLang = require(`@/assets/lang/${lang}/footer.json`);
+  const relationalLinksText = require(`@/assets/lang/${lang}/relational-links.json`);
+
+  cookies.setReferralCookie(ctx);
+
+  return {
+    props: {
+      lang,
+      metatagsDescriptions,
+      langJson,
+      navbarLang,
+      footerLang,
+      download,
+      relationalLinksText,
+    },
+  };
+}
+
+export default AntivirusPage;

--- a/src/pages/ultimate/annual/antivirus.tsx
+++ b/src/pages/ultimate/annual/antivirus.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from 'react';
 import { GetServerSidePropsContext } from 'next';
+import axios from 'axios';
 import { FooterText, MetatagsDescription, NavigationBarText } from '@/assets/types/layout/types';
 import Layout from '@/components/layout/Layout';
 import { MinimalNavbar } from '@/components/layout/navbars/MinimalNavbar';
@@ -20,12 +21,13 @@ import { downloadDriveLinks } from '@/lib/get-download-url';
 import { MinimalFooter } from '@/components/layout/footers/MinimalFooter';
 import { HorizontalPriceCard } from '@/components/shared/pricing/PriceCard/HorizontalPriceCard';
 import usePricing from '@/hooks/usePricing';
-import { PlanById, stripeService } from '@/services/stripe.service';
+import { PlanById, normalizePlanById } from '@/utils/priceHelper';
 import { analyticsService } from '@/services/ga.services';
 import { handleImpactEvent } from '@/services/impact.service';
 import { checkout } from '@/lib/auth';
 
 const ESSENTIAL_PLAN_PRICE_ID = 'price_1U6Ev3FAOdcgaBMQHxOAmWPO';
+const DEFAULT_CURRENCY = 'eur';
 const CLAIM_DEAL_CTA_SELECTOR = 'a[href$="#priceCard"], #choose-storage-button, #billingButtons button';
 const CLAIM_DEAL_EVENT = 'Claim Deal';
 
@@ -118,9 +120,30 @@ const AntivirusPage = ({
 
     let isStale = false;
 
-    stripeService.getPlanById(ESSENTIAL_PLAN_PRICE_ID, currencyValue).then((plan) => {
-      if (!isStale) setEssentialPlan(plan);
-    });
+    const fetchPrice = async (currencyToFetch: string) => {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_PAYMENTS_API}/object-storage/price`, {
+        params: { planId: ESSENTIAL_PLAN_PRICE_ID, currency: currencyToFetch },
+      });
+      return res.data;
+    };
+
+    const fetchEssentialPlan = async () => {
+      try {
+        let price;
+
+        try {
+          price = await fetchPrice(currencyValue ?? DEFAULT_CURRENCY);
+        } catch (error) {
+          price = await fetchPrice(DEFAULT_CURRENCY);
+        }
+
+        if (!isStale) setEssentialPlan(normalizePlanById(price));
+      } catch (error) {
+        console.error('Error fetching price by id:', error);
+      }
+    };
+
+    fetchEssentialPlan();
 
     return () => {
       isStale = true;

--- a/src/services/stripe.service.ts
+++ b/src/services/stripe.service.ts
@@ -55,15 +55,6 @@ export interface ProductsDataProps {
   };
 }
 
-export interface PlanById {
-  priceId: string;
-  storage: string;
-  price: number;
-  currency: string;
-  currencyValue: string;
-  interval: Interval;
-}
-
 async function getPrices(currencySpecified?: string) {
   const currency = await getCurrency(currencySpecified);
   const data = await fetchProductData(currency);
@@ -139,45 +130,6 @@ function transformProductData(individualsData: ProductValue[], businessData: Pro
   console.log(transformedData);
 
   return transformedData;
-}
-
-/**
- * Fetches a single Stripe price by its priceId, for prices that are not part of
- * the curated list returned by `getPrices` (antivirus, partner deals, etc).
- */
-async function getPlanById(priceId: string, currencySpecified?: string): Promise<PlanById | undefined> {
-  const currency = await getCurrency(currencySpecified);
-
-  const fetchPrice = async (currencyValue: string) => {
-    const res = await axios.get(`${process.env.NEXT_PUBLIC_PAYMENTS_API}/object-storage/price`, {
-      params: { planId: priceId, currency: currencyValue },
-    });
-    return res.data;
-  };
-
-  try {
-    let price;
-
-    try {
-      price = await fetchPrice(currency);
-    } catch (error) {
-      price = await fetchPrice('eur');
-    }
-
-    const normalizedPrice: PlanById = {
-      priceId: price.id,
-      storage: bytes(price.bytes),
-      price: price.decimalAmount,
-      currency: CURRENCY_MAP[price.currency] ?? price.currency,
-      currencyValue: price.currency,
-      interval: price.interval,
-    };
-
-    return normalizedPrice;
-  } catch (error) {
-    console.error('Error fetching price by id:', error);
-    return undefined;
-  }
 }
 
 async function getSelectedPrice(
@@ -300,7 +252,6 @@ const redirectToCheckoutForPcComponentes = (
 
 export const stripeService = {
   getPrices,
-  getPlanById,
   getSelectedPrice,
   getCoupon,
   getLifetimeCoupons,

--- a/src/services/stripe.service.ts
+++ b/src/services/stripe.service.ts
@@ -55,6 +55,15 @@ export interface ProductsDataProps {
   };
 }
 
+export interface PlanById {
+  priceId: string;
+  storage: string;
+  price: number;
+  currency: string;
+  currencyValue: string;
+  interval: Interval;
+}
+
 async function getPrices(currencySpecified?: string) {
   const currency = await getCurrency(currencySpecified);
   const data = await fetchProductData(currency);
@@ -130,6 +139,45 @@ function transformProductData(individualsData: ProductValue[], businessData: Pro
   console.log(transformedData);
 
   return transformedData;
+}
+
+/**
+ * Fetches a single Stripe price by its priceId, for prices that are not part of
+ * the curated list returned by `getPrices` (antivirus, partner deals, etc).
+ */
+async function getPlanById(priceId: string, currencySpecified?: string): Promise<PlanById | undefined> {
+  const currency = await getCurrency(currencySpecified);
+
+  const fetchPrice = async (currencyValue: string) => {
+    const res = await axios.get(`${process.env.NEXT_PUBLIC_PAYMENTS_API}/object-storage/price`, {
+      params: { planId: priceId, currency: currencyValue },
+    });
+    return res.data;
+  };
+
+  try {
+    let price;
+
+    try {
+      price = await fetchPrice(currency);
+    } catch (error) {
+      price = await fetchPrice('eur');
+    }
+
+    const normalizedPrice: PlanById = {
+      priceId: price.id,
+      storage: bytes(price.bytes),
+      price: price.decimalAmount,
+      currency: CURRENCY_MAP[price.currency] ?? price.currency,
+      currencyValue: price.currency,
+      interval: price.interval,
+    };
+
+    return normalizedPrice;
+  } catch (error) {
+    console.error('Error fetching price by id:', error);
+    return undefined;
+  }
 }
 
 async function getSelectedPrice(
@@ -252,6 +300,7 @@ const redirectToCheckoutForPcComponentes = (
 
 export const stripeService = {
   getPrices,
+  getPlanById,
   getSelectedPrice,
   getCoupon,
   getLifetimeCoupons,

--- a/src/utils/priceHelper.ts
+++ b/src/utils/priceHelper.ts
@@ -1,4 +1,19 @@
-import { Interval } from '@/services/stripe.service'
+import bytes from 'bytes';
+import { Interval } from '@/services/stripe.service';
+
+const CURRENCY_MAP = {
+    eur: '€',
+    usd: '$',
+};
+
+export interface PlanById {
+    priceId: string;
+    storage: string;
+    price: number;
+    currency: string;
+    currencyValue: string;
+    interval: Interval;
+}
 
 export const getMinimumPrice = (
     products: any,
@@ -12,3 +27,17 @@ export const getMinimumPrice = (
         ?(Math.floor(price * (decimalDiscount / 100) * 100) / 100).toFixed(2)
         : price.toFixed(2);
 }
+
+/**
+ * Normalizes a raw Stripe price (as returned by the payments API) into the shape
+ * the pricing components expect, for prices that are not part of the curated
+ * list returned by `stripeService.getPrices` (antivirus, partner deals, etc).
+ */
+export const normalizePlanById = (price: any): PlanById => ({
+    priceId: price.id,
+    storage: bytes(price.bytes),
+    price: price.decimalAmount,
+    currency: CURRENCY_MAP[price.currency] ?? price.currency,
+    currencyValue: price.currency,
+    interval: price.interval,
+});


### PR DESCRIPTION
1. Added in stripe.service a method to obtain the plan by price_id and then normalize the data format to be used in antivirus LP.
<img width="499" height="323" alt="data" src="https://github.com/user-attachments/assets/12a02e9c-69fd-44f8-a882-55803ecdc7c0" /> 
<img width="1762" height="942" alt="priceCard" src="https://github.com/user-attachments/assets/caa01b84-fdde-4e63-88a9-0f2f2e0a9f2b" />
<img width="1762" height="942" alt="driveweb" src="https://github.com/user-attachments/assets/95a6c02f-b3ef-4514-995d-b22777be0ced" />


2. Changed horizontalpriceCardSection and json documents, added 'year' label