### PR TITLE
[MKT-1025]fix/pricing section shows more plans than Ultimate in mobile version

### DIFF
--- a/src/components/shared/pricing/PricingSectionForMobile.tsx
+++ b/src/components/shared/pricing/PricingSectionForMobile.tsx
@@ -49,6 +49,12 @@ interface PriceTableProps {
   isValentinesMode?: boolean;
 }
 
+const STORAGE_BY_PLAN: Record<SwitchStorageOptions, string> = {
+  Essential: '1TB',
+  Premium: '3TB',
+  Ultimate: '5TB',
+};
+
 export const PricingSectionForMobile = ({
   textContent,
   products,
@@ -78,7 +84,7 @@ export const PricingSectionForMobile = ({
   isAffiliate,
   hideBillingController,
   isValentinesMode = false,
-  onlyUltimatePlan = false,
+  onlyUltimatePlan,
 }: PriceTableProps): JSX.Element => {
   const banner = require('@/assets/lang/en/banners.json');
 
@@ -124,14 +130,10 @@ export const PricingSectionForMobile = ({
     }
   };
 
-  const planStorage = onlyUltimatePlan
-    ? '5TB'
-    : storageSelected === 'Essential'
-    ? '1TB'
-    : storageSelected === 'Premium'
-    ? '3TB'
-    : '5TB';
+  const planStorage = onlyUltimatePlan ? STORAGE_BY_PLAN.Ultimate : STORAGE_BY_PLAN[storageSelected];
   const businessPlanStorage = businessStorageSelected === 'Standard' ? '1TB' : '2TB';
+
+  const hideStorageSelector = onlyUltimatePlan ? onlyUltimatePlan : false;
 
   return (
     <>
@@ -146,7 +148,7 @@ export const PricingSectionForMobile = ({
           darkMode={darkMode}
           activeStoragePlan={storageSelected}
           hideBillingController={hideBillingController}
-          hideStorageSelector={onlyUltimatePlan}
+          hideStorageSelector={hideStorageSelector}
         />
       )}
       {activeSwitchPlan !== 'Lifetime' && (

--- a/src/components/shared/pricing/PricingSectionForMobile.tsx
+++ b/src/components/shared/pricing/PricingSectionForMobile.tsx
@@ -27,6 +27,7 @@ interface PriceTableProps {
   businessBillingFrequency?: Interval;
   isFamilyPage?: boolean;
   hidePlanSelectorAndSwitch?: boolean;
+  onlyUltimatePlan?: boolean;
   darkMode?: boolean;
   hideFeatures?: boolean;
   showPromo?: boolean;
@@ -77,6 +78,7 @@ export const PricingSectionForMobile = ({
   isAffiliate,
   hideBillingController,
   isValentinesMode = false,
+  onlyUltimatePlan = false,
 }: PriceTableProps): JSX.Element => {
   const banner = require('@/assets/lang/en/banners.json');
 
@@ -122,7 +124,13 @@ export const PricingSectionForMobile = ({
     }
   };
 
-  const planStorage = storageSelected === 'Essential' ? '1TB' : storageSelected === 'Premium' ? '3TB' : '5TB';
+  const planStorage = onlyUltimatePlan
+    ? '5TB'
+    : storageSelected === 'Essential'
+    ? '1TB'
+    : storageSelected === 'Premium'
+    ? '3TB'
+    : '5TB';
   const businessPlanStorage = businessStorageSelected === 'Standard' ? '1TB' : '2TB';
 
   return (
@@ -138,6 +146,7 @@ export const PricingSectionForMobile = ({
           darkMode={darkMode}
           activeStoragePlan={storageSelected}
           hideBillingController={hideBillingController}
+          hideStorageSelector={onlyUltimatePlan}
         />
       )}
       {activeSwitchPlan !== 'Lifetime' && (

--- a/src/components/shared/pricing/PricingSectionWrapper.tsx
+++ b/src/components/shared/pricing/PricingSectionWrapper.tsx
@@ -332,6 +332,7 @@ export const PricingSectionWrapper = ({
           showPromo={showPromo}
           isValentinesMode={isValentinesMode}
           hideFreeCard={hideFreeCard}
+          onlyUltimatePlan={onlyUltimatePlan}
         />
         {textContent.ctaCompare && (
           <a

--- a/src/components/shared/pricing/components/PlanSelectorForMobile.tsx
+++ b/src/components/shared/pricing/components/PlanSelectorForMobile.tsx
@@ -12,6 +12,7 @@ interface PlanSwitchProps {
   isMonthly?: boolean;
   darkMode?: boolean;
   hideBillingController?: boolean;
+  hideStorageSelector?: boolean;
   onPlanTypeChange: (activeSwitchPlan: string, billedFrequency?: Interval) => void;
   onStorageChange: (activeStoragePlan: string) => void;
 }
@@ -26,6 +27,7 @@ export const PlanSelectorForMobile = ({
   darkMode,
 
   hideBillingController,
+  hideStorageSelector,
 }: PlanSwitchProps): JSX.Element => (
   <>
     {!hideBillingController && (
@@ -72,51 +74,53 @@ export const PlanSelectorForMobile = ({
       </div>
     )}
 
-    <div
-      id="billingButtons"
-      className={`flex w-[345px] flex-row justify-between rounded-lg ${
-        darkMode ? 'bg-neutral-90/10' : 'bg-cool-gray-10'
-      } p-0.5`}
-    >
-      <button
-        type="button"
-        onClick={() => {
-          onStorageChange('Essential');
-        }}
-        className={`rounded-6 flex w-[107px] flex-row items-center justify-center gap-3 rounded-lg px-3 py-1 text-sm ${
-          activeStoragePlan === 'Essential'
-            ? `bg-white font-semibold text-primary shadow-sm`
-            : `font-regular text-cool-gray-50 `
-        }`}
+    {!hideStorageSelector && (
+      <div
+        id="billingButtons"
+        className={`flex w-[345px] flex-row justify-between rounded-lg ${
+          darkMode ? 'bg-neutral-90/10' : 'bg-cool-gray-10'
+        } p-0.5`}
       >
-        {textContent.planStorage.essential}
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          onStorageChange('Premium');
-        }}
-        className={`rounded-6 flex w-[107px] flex-row items-center justify-center gap-3 rounded-lg px-3 py-1 text-sm ${
-          activeStoragePlan === 'Premium'
-            ? `bg-white font-semibold text-primary shadow-sm`
-            : `font-regular text-cool-gray-50`
-        }`}
-      >
-        {textContent.planStorage.premium}
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          onStorageChange('Ultimate');
-        }}
-        className={`rounded-6 flex w-[107px] flex-row items-center justify-center gap-3 rounded-lg px-3 py-1 text-sm ${
-          activeStoragePlan === 'Ultimate'
-            ? `bg-white font-semibold text-primary shadow-sm`
-            : `font-regular text-cool-gray-50`
-        }`}
-      >
-        {textContent.planStorage.ultimate}
-      </button>
-    </div>
+        <button
+          type="button"
+          onClick={() => {
+            onStorageChange('Essential');
+          }}
+          className={`rounded-6 flex w-[107px] flex-row items-center justify-center gap-3 rounded-lg px-3 py-1 text-sm ${
+            activeStoragePlan === 'Essential'
+              ? `bg-white font-semibold text-primary shadow-sm`
+              : `font-regular text-cool-gray-50 `
+          }`}
+        >
+          {textContent.planStorage.essential}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onStorageChange('Premium');
+          }}
+          className={`rounded-6 flex w-[107px] flex-row items-center justify-center gap-3 rounded-lg px-3 py-1 text-sm ${
+            activeStoragePlan === 'Premium'
+              ? `bg-white font-semibold text-primary shadow-sm`
+              : `font-regular text-cool-gray-50`
+          }`}
+        >
+          {textContent.planStorage.premium}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onStorageChange('Ultimate');
+          }}
+          className={`rounded-6 flex w-[107px] flex-row items-center justify-center gap-3 rounded-lg px-3 py-1 text-sm ${
+            activeStoragePlan === 'Ultimate'
+              ? `bg-white font-semibold text-primary shadow-sm`
+              : `font-regular text-cool-gray-50`
+          }`}
+        >
+          {textContent.planStorage.ultimate}
+        </button>
+      </div>
+    )}
   </>
 );


### PR DESCRIPTION
Added in pricingSectionForMobile to receive onlyUltimatePlan like in desktop version and added hidePlanSelector in PlanSelector in mobile version if is onlyUltimatePlan.
before:
<img width="455" height="673" alt="before" src="https://github.com/user-attachments/assets/af4eb02b-af0d-4d59-ab83-3224e800be3c" />


after:
<img width="455" height="673" alt="after" src="https://github.com/user-attachments/assets/115603eb-8b00-43f3-b66e-4ea070f5d02a" />
