### PR TITLE
[MKT-1050]feat/duplicate ultimate annual page

### DIFF
--- a/src/components/shared/pricing/PriceCard/HorizontalPriceCard.tsx
+++ b/src/components/shared/pricing/PriceCard/HorizontalPriceCard.tsx
@@ -20,6 +20,7 @@ import {
 } from '@phosphor-icons/react';
 import { checkout } from '@/lib/auth';
 import { PromoCodeProps } from '@/lib/types';
+import { getTrackingParams } from '@/lib/cookies';
 
 const iconList: Record<string, Icon[]> = {
   '1TB': [
@@ -124,6 +125,7 @@ export const HorizontalPriceCard = ({
       planType: 'individual',
       currency: currencyValue ?? 'eur',
       promoCodeId: coupon?.name,
+      trackingParams: getTrackingParams(),
     });
   }
   return (

--- a/src/components/templates/ultimateAnnualTemplate.tsx
+++ b/src/components/templates/ultimateAnnualTemplate.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { GetServerSidePropsContext } from 'next';
+import { FooterText, MetatagsDescription, NavigationBarText } from '@/assets/types/layout/types';
+import Layout from '@/components/layout/Layout';
+import { PromoCodeName } from '@/lib/types';
+import { MinimalFooter } from '@/components/layout/footers/MinimalFooter';
+import { HorizontalPriceCard } from '@/components/shared/pricing/PriceCard/HorizontalPriceCard';
+import usePricing from '@/hooks/usePricing';
+import { Interval } from '@/services/stripe.service';
+import Navbar from '@/components/layout/navbars/Navbar';
+import HeroSection from '@/components/partnersTemplate/HeroSection';
+import FeaturesSection from '@/components/drive/FeaturesSection';
+import { SpecialOfferText } from '@/assets/types/specialOfferTemplate';
+import HorizontalScrollableSection from '@/components/home/HorizontalScrollableSection';
+import TrustedSection from '@/components/home/TrustedSection';
+
+export interface UltimateAnnualTemplateProps {
+  lang: GetServerSidePropsContext['locale'];
+  metatagsDescriptions: MetatagsDescription[];
+  navbarLang: NavigationBarText;
+  langJson: SpecialOfferText;
+  footerLang: FooterText;
+  couponCodeForLifetime?: PromoCodeName;
+}
+
+export const UltimateAnnualTemplate = ({ 
+    metatagsDescriptions,
+    langJson,
+    lang, 
+    footerLang,
+    navbarLang,
+    couponCodeForLifetime = PromoCodeName.WEWE,
+}: UltimateAnnualTemplateProps): JSX.Element => {
+  const metatags = metatagsDescriptions.find((desc) => desc.id === 'special-offer');
+  const locale = lang as string;
+
+  const { products, currency, currencyValue, lifetimeCoupon } = usePricing({
+    couponCodeForLifetime: couponCodeForLifetime,
+  });
+
+  const ultimatePlan = products?.individuals?.[Interval.Year]?.find((plan: any) => plan.storage === '5TB');
+  const decimalDiscountForLifetime = lifetimeCoupon?.percentOff && 100 - lifetimeCoupon.percentOff;
+  const percentOff = lifetimeCoupon?.percentOff === undefined ? '0' : String(lifetimeCoupon.percentOff);
+
+  return (
+      <Layout title={metatags?.title ?? ''} description={metatags?.description ?? ''} segmentName="Home" lang={lang}>
+        <Navbar lang={locale} textContent={navbarLang} cta={['payment']} isLinksHidden hideCTA hideLogoLink />
+
+        <HeroSection textContent={langJson.HeroSection} percentOff={percentOff} showSubtitle={false} />
+
+        {ultimatePlan && (
+          <div className="flex w-full justify-center px-6 py-12 lg:px-0 lg:py-24" id="priceCard">
+            <HorizontalPriceCard
+              decimalDiscountValue={decimalDiscountForLifetime || undefined}
+              storage={ultimatePlan.storage}
+              popular={false}
+              currency={currency}
+              priceBefore={ultimatePlan.price.toString().split('.')[0]}
+              price={Number(ultimatePlan.price)}
+              planId={ultimatePlan.priceId}
+              currencyValue={currencyValue}
+              coupon={lifetimeCoupon}
+            />
+          </div>
+        )}
+
+        <FeaturesSection textContent={langJson.FeaturesSection} lang={lang} download={false} showLastSection={false} />
+
+        <TrustedSection textContent={langJson.TrustedBySection} bottomBar={false} />
+
+        <HorizontalScrollableSection textContent={langJson.NextGenSection} />
+
+        <MinimalFooter footerLang={footerLang.FooterSection} lang={locale} />
+      </Layout>
+  );
+};

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -363,6 +363,7 @@ export enum PromoCodeName {
   kudettech = 'KUDETTECH',
   niklas = 'NIKLAS',
   zackshutt = 'ZACKSHUTT',
+  ultimate94 = 'ULTIMATE94',
 }
 
 export interface PromoCodeProps {

--- a/src/pages/ultimate/annual-ultimate-ninetyfour.tsx
+++ b/src/pages/ultimate/annual-ultimate-ninetyfour.tsx
@@ -3,7 +3,7 @@ import { GetServerSidePropsContext } from "next";
 import cookies from "@/lib/cookies";
 import { PromoCodeName } from "@/lib/types";
 
-const AnnualUltimate94 = (props: UltimateAnnualTemplateProps) => <UltimateAnnualTemplate {...props} couponCodeForLifetime={PromoCodeName.ultimate94}/>
+const AnnualUltimateNinetyFour = (props: UltimateAnnualTemplateProps) => <UltimateAnnualTemplate {...props} couponCodeForLifetime={PromoCodeName.ultimate94}/>
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const lang = ctx.locale;
@@ -26,4 +26,4 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   };
 }
 
-export default AnnualUltimate94;
+export default AnnualUltimateNinetyFour;

--- a/src/pages/ultimate/annual-ultimate94.tsx
+++ b/src/pages/ultimate/annual-ultimate94.tsx
@@ -1,8 +1,9 @@
 import { UltimateAnnualTemplate, UltimateAnnualTemplateProps } from "@/components/templates/ultimateAnnualTemplate";
 import { GetServerSidePropsContext } from "next";
 import cookies from "@/lib/cookies";
+import { PromoCodeName } from "@/lib/types";
 
-const AnnualUltimate = (props: UltimateAnnualTemplateProps) => <UltimateAnnualTemplate {...props} />
+const AnnualUltimate94 = (props: UltimateAnnualTemplateProps) => <UltimateAnnualTemplate {...props} couponCodeForLifetime={PromoCodeName.ultimate94}/>
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const lang = ctx.locale;
@@ -25,4 +26,4 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   };
 }
 
-export default AnnualUltimate;
+export default AnnualUltimate94;


### PR DESCRIPTION
Duplicate /ultimate/annual page and apply the ULTIMATE94 coupon. The route of new LP is /ultimate/annual-ultimate-ninetyfour.

Changes:
1. Created UltimateAnnualTemplate.tsx to reuse the code in replication of ultimate annual LPs.
2. Added trackingParams in checkout method in HorizontalPriceCard.
3. Added ULTIMATE94 coupon in index.ts.